### PR TITLE
Adding Windows and Amazon-Linux build targets to pr-build

### DIFF
--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -47,6 +47,9 @@ phases:
       - ECS_AGENT_TAR="ecs-agent-v${AGENT_VERSION}.tar"
       - CSI_DRIVER_TAR="./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver.tar"
       - ECS_AGENT_RPM="amazon-ecs-init-${AGENT_VERSION}-1.x86_64.rpm"
+      - WINDOWS_EXE="amazon-ecs-agent.exe"
+      - AMZN_LINUX_2_RPM="amazon-ecs-init-${AGENT_VERSION}-1.amzn2.x86_64.rpm"
+      - AMZN_LINUX_2023_RPM="amazon-ecs-init-${AGENT_VERSION}-1.amzn2023.x86_64.rpm"
       - echo $(pwd) 2>&1 | tee -a $BUILD_LOG
 
       # Path readjustment for codebuild testing with fork and setting GOPATH appropriately
@@ -58,6 +61,12 @@ phases:
           mv $GITHUBUSERNAME aws
         fi
       - cd aws/amazon-ecs-agent
+
+      # Build Windows executable
+      - make windows-exe 2>&1 | tee -a $BUILD_LOG
+
+      # Build Amazon Linux RPMs
+      - make amazon-linux-rpm-integrated 2>&1 | tee -a $BUILD_LOG
 
       # Building agent tars
       - GO111MODULE=auto
@@ -73,6 +82,8 @@ phases:
           ECS_AGENT_RPM="amazon-ecs-init-${AGENT_VERSION}-1.aarch64.rpm"
           ECS_AGENT_TAR="ecs-agent-arm64-v${AGENT_VERSION}.tar"
           CSI_DRIVER_TAR="./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver-arm64.tar"
+          AMZN_LINUX_2_RPM="amazon-ecs-init-${AGENT_VERSION}-1.amzn2.aarch64.rpm"
+          AMZN_LINUX_2023_RPM="amazon-ecs-init-${AGENT_VERSION}-1.amzn2023.aarch64.rpm"
         fi
 
   post_build:
@@ -82,6 +93,9 @@ artifacts:
   files:
     - $ECS_AGENT_TAR
     - $ECS_AGENT_RPM
+    - $WINDOWS_EXE
+    - $AMZN_LINUX_2_RPM
+    - $AMZN_LINUX_2023_RPM
     - $BUILD_LOG
     - $CSI_DRIVER_TAR
   name: $CODEBUILD_RESOLVED_SOURCE_VERSION


### PR DESCRIPTION
This pull request adds a make target for windows in the Makefile. It also adds build commands in the pr-build file to make Windows.exe and Amazon-Linux RPM artifacts. 

