### PR TITLE
This commit comments out the directory navigation for testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,7 +285,7 @@ release-agent: get-cni-sources
 codebuild: .out-stamp
 	$(MAKE) release TARGET_OS="linux"
 	TARGET_OS="linux" ./scripts/local-save
-	$(MAKE) docker-release TARGET_OS="windows"
+	$(MAKE) windows-docker-release
 	TARGET_OS="windows" ./scripts/local-save
 
 netkitten:

--- a/Makefile
+++ b/Makefile
@@ -398,7 +398,7 @@ get-deps-init:
 	GO111MODULE=on go install github.com/fzipp/gocyclo/cmd/gocyclo@v0.6.0
 	GO111MODULE=on go install honnef.co/go/tools/cmd/staticcheck@v0.4.0
 
-amazon-linux-sources.tgz:
+amazon-linux-sources.tgz: get-cni-sources
 	./scripts/update-version.sh
 	cp packaging/amazon-linux-ami-integrated/ecs-agent.spec ecs-agent.spec
 	cp packaging/amazon-linux-ami-integrated/ecs.conf ecs.conf
@@ -406,7 +406,7 @@ amazon-linux-sources.tgz:
 	cp packaging/amazon-linux-ami-integrated/amazon-ecs-volume-plugin.conf amazon-ecs-volume-plugin.conf
 	cp packaging/amazon-linux-ami-integrated/amazon-ecs-volume-plugin.service amazon-ecs-volume-plugin.service
 	cp packaging/amazon-linux-ami-integrated/amazon-ecs-volume-plugin.socket amazon-ecs-volume-plugin.socket
-	tar -czf ./sources.tgz ecs-init scripts misc agent amazon-ecs-cni-plugins amazon-vpc-cni-plugins agent-container Makefile VERSION RELEASE_COMMIT
+	tar -czf ./sources.tgz ecs-init scripts misc agent amazon-ecs-cni-plugins amazon-vpc-cni-plugins agent-container Makefile VERSION GO_VERSION
 
 .amazon-linux-rpm-integrated-done: amazon-linux-sources.tgz
 	test -e SOURCES || ln -s . SOURCES

--- a/Makefile
+++ b/Makefile
@@ -428,11 +428,6 @@ amazon-linux-rpm-integrated: .amazon-linux-rpm-integrated-done
 	find RPMS/ -type f -exec cp {} . \;
 	touch .generic-rpm-integrated-done
 
-# Create windows.exe target
-windows-exe: windows-docker-release
-	TARGET_OS="windows" ./scripts/local-save
-
-
 # Build init rpm
 generic-rpm-integrated: .generic-rpm-integrated-done
 

--- a/buildspecs/pr-build-ubuntu.yml
+++ b/buildspecs/pr-build-ubuntu.yml
@@ -30,13 +30,15 @@ phases:
       - echo $(pwd) 2>&1 | tee -a $BUILD_LOG
 
       # Path readjustment for codebuild testing with fork and setting GOPATH appropriately
-      - cd ../../../..
-      - cd src/github.com
-      - |
-        if [[ $GITHUBUSERNAME != "aws" ]] ; then
-          mv $GITHUBUSERNAME aws
-        fi
-      - cd aws/amazon-ecs-agent
+      #- cd ../../../..
+      #- cd src/github.com
+      #- |
+      #  if [[ $GITHUBUSERNAME != "aws" ]] ; then
+      #    mv $GITHUBUSERNAME aws
+      #  fi
+      #- cd aws/amazon-ecs-agent
+
+# Uncomment the above section before merging to main repo
 
       # Building agent deb
       - GO111MODULE=auto

--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -64,7 +64,7 @@ phases:
 
       # Add path to forked directory for POC testing
       # Remove this line and uncomment the above section before merging to main aws account
-      - cd $GITHUBUSERNAME/amazon-ecs-agent
+      - cd Ephylouise/amazon-ecs-agent
 
       # Build Windows executable
       - make windows-exe 2>&1 | tee -a $BUILD_LOG

--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -48,6 +48,8 @@ phases:
       - CSI_DRIVER_TAR="./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver.tar"
       - ECS_AGENT_RPM="amazon-ecs-init-${AGENT_VERSION}-1.x86_64.rpm"
       - WINDOWS_EXE="amazon-ecs-agent.exe"
+      - AMZN_LINUX_2_RPM="amazon-ecs-init-${AGENT_VERSION}-1.${AMZN_LINUX_VERSION}.${architecture}.rpm"
+      - AMZN_LINUX_2023_RPM="amazon-ecs-init-${AGENT_VERSION}-1.${AMZN_LINUX_VERSION}.${architecture}.rpm"
       
       # Determine Amazon Linux version
       - |
@@ -75,10 +77,10 @@ phases:
       - make windows-exe 2>&1 | tee -a $BUILD_LOG
 
       # Build Amazon Linux 2 RPMs
-      - make amazon-linux-rpm-integrated AMZN_LINUX_VERSION="amzn2" ARCH=$architecture 2>&1 | tee -a $BUILD_LOG
+      - make amazon-linux-rpm-integrated AMZN_LINUX_VERSION="amzn2" 2>&1 | tee -a $BUILD_LOG
 
       # Build Amazon Linux 2023 RPMs
-      - make amazon-linux-rpm-integrated AMZN_LINUX_VERSION="amzn2023" ARCH=$architecture 2>&1 | tee -a $BUILD_LOG
+      - make amazon-linux-rpm-integrated AMZN_LINUX_VERSION="amzn2023" 2>&1 | tee -a $BUILD_LOG
 
       # Building agent tars
       - GO111MODULE=auto
@@ -95,6 +97,8 @@ phases:
           ECS_AGENT_RPM="amazon-ecs-init-${AGENT_VERSION}-1.aarch64.rpm"
           ECS_AGENT_TAR="ecs-agent-arm64-v${AGENT_VERSION}.tar"
           CSI_DRIVER_TAR="./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver-arm64.tar"
+          AMZN_LINUX_2_RPM="amazon-ecs-init-${AGENT_VERSION}-1.amzn2.aarch64.rpm" 
+          AMZN_LINUX_2023_RPM="amazon-ecs-init-${AGENT_VERSION}-1.amzn2023.aarch64.rpm"
         fi
 
   post_build:
@@ -105,8 +109,8 @@ artifacts:
     - $ECS_AGENT_TAR
     - $ECS_AGENT_RPM
     - $WINDOWS_EXE
-    - "ecs-init-${AGENT_VERSION}-1.amzn2.${architecture}.rpm"
-    - "ecs-init-${AGENT_VERSION}-1.amzn2023.${architecture}.rpm"
+    - $AMZN_LINUX_2_RPM
+    - $AMZN_LINUX_2023_RPM
     - $BUILD_LOG
     - $CSI_DRIVER_TAR
   name: $CODEBUILD_RESOLVED_SOURCE_VERSION

--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -62,10 +62,6 @@ phases:
       #  fi
       #- cd aws/amazon-ecs-agent
 
-      # Add path to forked directory for POC testing
-      # Remove this line and uncomment the above section before merging to main aws account
-      - cd Ephylouise/amazon-ecs-agent
-
       # Build Windows executable
       - make windows-exe 2>&1 | tee -a $BUILD_LOG
 

--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -53,14 +53,18 @@ phases:
       - echo $(pwd) 2>&1 | tee -a $BUILD_LOG
 
       # Path readjustment for codebuild testing with fork and setting GOPATH appropriately
-      - cd ../../../..
-      - export GOPATH=$GOPATH:$(pwd)
-      - cd src/github.com
-      - |
-        if [[ $GITHUBUSERNAME != "aws" ]] ; then
-          mv $GITHUBUSERNAME aws
-        fi
-      - cd aws/amazon-ecs-agent
+      #- cd ../../../..
+      #- export GOPATH=$GOPATH:$(pwd)
+      #- cd src/github.com
+      #- |
+      #  if [[ $GITHUBUSERNAME != "aws" ]] ; then
+      #    mv $GITHUBUSERNAME aws
+      #  fi
+      #- cd aws/amazon-ecs-agent
+
+      # Add path to forked directory for POC testing
+      # Remove this line and uncomment the above section before merging to main aws account
+      - cd $GITHUBUSERNAME/amazon-ecs-agent
 
       # Build Windows executable
       - make windows-exe 2>&1 | tee -a $BUILD_LOG

--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -47,6 +47,9 @@ phases:
       - ECS_AGENT_TAR="ecs-agent-v${AGENT_VERSION}.tar"
       - CSI_DRIVER_TAR="./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver.tar"
       - ECS_AGENT_RPM="amazon-ecs-init-${AGENT_VERSION}-1.x86_64.rpm"
+      - WINDOWS_EXE="amazon-ecs-agent.exe"
+      - AMZN_LINUX_2_RPM="amazon-ecs-init-${AGENT_VERSION}-1.amzn2.x86_64.rpm"
+      - AMZN_LINUX_2023_RPM="amazon-ecs-init-${AGENT_VERSION}-1.amzn2023.x86_64.rpm"
       - echo $(pwd) 2>&1 | tee -a $BUILD_LOG
 
       # Path readjustment for codebuild testing with fork and setting GOPATH appropriately
@@ -58,6 +61,12 @@ phases:
           mv $GITHUBUSERNAME aws
         fi
       - cd aws/amazon-ecs-agent
+
+      # Build Windows executable
+      - make windows-exe 2>&1 | tee -a $BUILD_LOG
+
+      # Build Amazon Linux RPMs
+      - make amazon-linux-rpm-integrated 2>&1 | tee -a $BUILD_LOG
 
       # Building agent tars
       - GO111MODULE=auto
@@ -73,6 +82,8 @@ phases:
           ECS_AGENT_RPM="amazon-ecs-init-${AGENT_VERSION}-1.aarch64.rpm"
           ECS_AGENT_TAR="ecs-agent-arm64-v${AGENT_VERSION}.tar"
           CSI_DRIVER_TAR="./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver-arm64.tar"
+          AMZN_LINUX_2_RPM="amazon-ecs-init-${AGENT_VERSION}-1.amzn2.aarch64.rpm"
+          AMZN_LINUX_2023_RPM="amazon-ecs-init-${AGENT_VERSION}-1.amzn2023.aarch64.rpm"
         fi
 
   post_build:
@@ -82,6 +93,9 @@ artifacts:
   files:
     - $ECS_AGENT_TAR
     - $ECS_AGENT_RPM
+    - $WINDOWS_EXE
+    - $AMZN_LINUX_2_RPM
+    - $AMZN_LINUX_2023_RPM
     - $BUILD_LOG
     - $CSI_DRIVER_TAR
   name: $CODEBUILD_RESOLVED_SOURCE_VERSION

--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -74,7 +74,7 @@ phases:
       #- cd aws/amazon-ecs-agent
 
       # Build Windows executable
-      - make windows-exe 2>&1 | tee -a $BUILD_LOG
+      - make codebuild 2>&1 | tee -a $BUILD_LOG
 
       # Build Amazon Linux 2 RPMs
       - make amazon-linux-rpm-integrated AMZN_LINUX_VERSION="amzn2" 2>&1 | tee -a $BUILD_LOG

--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -3,7 +3,7 @@ version: 0.2
 env:
   variables:
     # Github username of the forked repo on which to make builds
-    GITHUBUSERNAME: aws
+    GITHUBUSERNAME: ephylouise
 
 phases:
   install:
@@ -48,8 +48,17 @@ phases:
       - CSI_DRIVER_TAR="./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver.tar"
       - ECS_AGENT_RPM="amazon-ecs-init-${AGENT_VERSION}-1.x86_64.rpm"
       - WINDOWS_EXE="amazon-ecs-agent.exe"
-      - AMZN_LINUX_2_RPM="amazon-ecs-init-${AGENT_VERSION}-1.amzn2.x86_64.rpm"
-      - AMZN_LINUX_2023_RPM="amazon-ecs-init-${AGENT_VERSION}-1.amzn2023.x86_64.rpm"
+      
+      # Determine Amazon Linux version
+      - |
+        if grep -q "amzn2" /etc/os-release; then
+          AMZN_LINUX_VERSION="amzn2"
+        elif grep -q "amzn2023" /etc/os-release; then
+          AMZN_LINUX_VERSION="amzn2023"
+        else
+          AMZN_LINUX_VERSION=""
+        fi
+
       - echo $(pwd) 2>&1 | tee -a $BUILD_LOG
 
       # Path readjustment for codebuild testing with fork and setting GOPATH appropriately
@@ -65,8 +74,11 @@ phases:
       # Build Windows executable
       - make windows-exe 2>&1 | tee -a $BUILD_LOG
 
-      # Build Amazon Linux RPMs
-      - make amazon-linux-rpm-integrated 2>&1 | tee -a $BUILD_LOG
+      # Build Amazon Linux 2 RPMs
+      - make amazon-linux-rpm-integrated AMZN_LINUX_VERSION="amzn2" ARCH=$architecture 2>&1 | tee -a $BUILD_LOG
+
+      # Build Amazon Linux 2023 RPMs
+      - make amazon-linux-rpm-integrated AMZN_LINUX_VERSION="amzn2023" ARCH=$architecture 2>&1 | tee -a $BUILD_LOG
 
       # Building agent tars
       - GO111MODULE=auto
@@ -74,6 +86,7 @@ phases:
       - make generic-rpm-integrated 2>&1 | tee -a $BUILD_LOG
       - make -C ./ecs-agent/daemonimages/csidriver 2>&1 | tee -a $BUILD_LOG
       - ls
+      
       # Rename artifacts for architecture
       - |
         if [[ $architecture == "arm64" ]] ; then
@@ -82,8 +95,6 @@ phases:
           ECS_AGENT_RPM="amazon-ecs-init-${AGENT_VERSION}-1.aarch64.rpm"
           ECS_AGENT_TAR="ecs-agent-arm64-v${AGENT_VERSION}.tar"
           CSI_DRIVER_TAR="./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver-arm64.tar"
-          AMZN_LINUX_2_RPM="amazon-ecs-init-${AGENT_VERSION}-1.amzn2.aarch64.rpm"
-          AMZN_LINUX_2023_RPM="amazon-ecs-init-${AGENT_VERSION}-1.amzn2023.aarch64.rpm"
         fi
 
   post_build:
@@ -94,8 +105,8 @@ artifacts:
     - $ECS_AGENT_TAR
     - $ECS_AGENT_RPM
     - $WINDOWS_EXE
-    - $AMZN_LINUX_2_RPM
-    - $AMZN_LINUX_2023_RPM
+    - "ecs-init-${AGENT_VERSION}-1.amzn2.${architecture}.rpm"
+    - "ecs-init-${AGENT_VERSION}-1.amzn2023.${architecture}.rpm"
     - $BUILD_LOG
     - $CSI_DRIVER_TAR
   name: $CODEBUILD_RESOLVED_SOURCE_VERSION


### PR DESCRIPTION
The CodeBuilds for testing if all the All-Dogs artifacts are being made are failing due to the directory navigation in the buildspecs. They are temporarily commented out to continue the Proof of Concept testing on my forked repository. 