### PR TITLE
Added logic in pr-build to handle amazon-linux version and architecture renaming

### DIFF
--- a/buildspecs/pr-build-ubuntu.yml
+++ b/buildspecs/pr-build-ubuntu.yml
@@ -30,13 +30,15 @@ phases:
       - echo $(pwd) 2>&1 | tee -a $BUILD_LOG
 
       # Path readjustment for codebuild testing with fork and setting GOPATH appropriately
-      - cd ../../../..
-      - cd src/github.com
-      - |
-        if [[ $GITHUBUSERNAME != "aws" ]] ; then
-          mv $GITHUBUSERNAME aws
-        fi
-      - cd aws/amazon-ecs-agent
+      #- cd ../../../..
+      #- cd src/github.com
+      #- |
+      #  if [[ $GITHUBUSERNAME != "aws" ]] ; then
+      #    mv $GITHUBUSERNAME aws
+      #  fi
+      #- cd aws/amazon-ecs-agent
+
+# Uncomment the above section before merging to main repo
 
       # Building agent deb
       - GO111MODULE=auto

--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -64,7 +64,7 @@ phases:
 
       # Add path to forked directory for POC testing
       # Remove this line and uncomment the above section before merging to main aws account
-      - cd $GITHUBUSERNAME/amazon-ecs-agent
+      - cd Ephylouise/amazon-ecs-agent
 
       # Build Windows executable
       - make windows-exe 2>&1 | tee -a $BUILD_LOG

--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -62,10 +62,6 @@ phases:
       #  fi
       #- cd aws/amazon-ecs-agent
 
-      # Add path to forked directory for POC testing
-      # Remove this line and uncomment the above section before merging to main aws account
-      - cd Ephylouise/amazon-ecs-agent
-
       # Build Windows executable
       - make windows-exe 2>&1 | tee -a $BUILD_LOG
 

--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -53,14 +53,18 @@ phases:
       - echo $(pwd) 2>&1 | tee -a $BUILD_LOG
 
       # Path readjustment for codebuild testing with fork and setting GOPATH appropriately
-      - cd ../../../..
-      - export GOPATH=$GOPATH:$(pwd)
-      - cd src/github.com
-      - |
-        if [[ $GITHUBUSERNAME != "aws" ]] ; then
-          mv $GITHUBUSERNAME aws
-        fi
-      - cd aws/amazon-ecs-agent
+      #- cd ../../../..
+      #- export GOPATH=$GOPATH:$(pwd)
+      #- cd src/github.com
+      #- |
+      #  if [[ $GITHUBUSERNAME != "aws" ]] ; then
+      #    mv $GITHUBUSERNAME aws
+      #  fi
+      #- cd aws/amazon-ecs-agent
+
+      # Add path to forked directory for POC testing
+      # Remove this line and uncomment the above section before merging to main aws account
+      - cd $GITHUBUSERNAME/amazon-ecs-agent
 
       # Build Windows executable
       - make windows-exe 2>&1 | tee -a $BUILD_LOG

--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -47,6 +47,9 @@ phases:
       - ECS_AGENT_TAR="ecs-agent-v${AGENT_VERSION}.tar"
       - CSI_DRIVER_TAR="./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver.tar"
       - ECS_AGENT_RPM="amazon-ecs-init-${AGENT_VERSION}-1.x86_64.rpm"
+      - WINDOWS_EXE="amazon-ecs-agent.exe"
+      - AMZN_LINUX_2_RPM="amazon-ecs-init-${AGENT_VERSION}-1.amzn2.x86_64.rpm"
+      - AMZN_LINUX_2023_RPM="amazon-ecs-init-${AGENT_VERSION}-1.amzn2023.x86_64.rpm"
       - echo $(pwd) 2>&1 | tee -a $BUILD_LOG
 
       # Path readjustment for codebuild testing with fork and setting GOPATH appropriately
@@ -58,6 +61,12 @@ phases:
           mv $GITHUBUSERNAME aws
         fi
       - cd aws/amazon-ecs-agent
+
+      # Build Windows executable
+      - make windows-exe 2>&1 | tee -a $BUILD_LOG
+
+      # Build Amazon Linux RPMs
+      - make amazon-linux-rpm-integrated 2>&1 | tee -a $BUILD_LOG
 
       # Building agent tars
       - GO111MODULE=auto
@@ -73,6 +82,8 @@ phases:
           ECS_AGENT_RPM="amazon-ecs-init-${AGENT_VERSION}-1.aarch64.rpm"
           ECS_AGENT_TAR="ecs-agent-arm64-v${AGENT_VERSION}.tar"
           CSI_DRIVER_TAR="./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver-arm64.tar"
+          AMZN_LINUX_2_RPM="amazon-ecs-init-${AGENT_VERSION}-1.amzn2.aarch64.rpm"
+          AMZN_LINUX_2023_RPM="amazon-ecs-init-${AGENT_VERSION}-1.amzn2023.aarch64.rpm"
         fi
 
   post_build:
@@ -82,6 +93,9 @@ artifacts:
   files:
     - $ECS_AGENT_TAR
     - $ECS_AGENT_RPM
+    - $WINDOWS_EXE
+    - $AMZN_LINUX_2_RPM
+    - $AMZN_LINUX_2023_RPM
     - $BUILD_LOG
     - $CSI_DRIVER_TAR
   name: $CODEBUILD_RESOLVED_SOURCE_VERSION


### PR DESCRIPTION
Added a block in pr-build to detect the Amazon-Linux version. 

Added Amazon-Linux to the renaming structure for "arm64" architecture. 

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
