### PR TITLE
Move new makge targets after global environment var

### DIFF
--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -52,26 +52,26 @@ phases:
       - echo $(pwd) 2>&1 | tee -a $BUILD_LOG
 
       # Path readjustment for codebuild testing with fork and setting GOPATH appropriately
-      #- cd ../../../..
-      #- export GOPATH=$GOPATH:$(pwd)
-      #- cd src/github.com
-      #- |
-      #  if [[ $GITHUBUSERNAME != "aws" ]] ; then
-      #    mv $GITHUBUSERNAME aws
-      #  fi
-      #- cd aws/amazon-ecs-agent
-
-      # Build Windows executable
-      - make windows-docker-release 2>&1 | tee -a $BUILD_LOG
-
-      # Build Amazon Linux 2 RPMs
-      - make amazon-linux-rpm-integrated 2>&1 | tee -a $BUILD_LOG
+      - cd ../../../..
+      - export GOPATH=$GOPATH:$(pwd)
+      - cd src/github.com
+      - |
+        if [[ $GITHUBUSERNAME != "aws" ]] ; then
+          mv $GITHUBUSERNAME aws
+        fi
+      - cd aws/amazon-ecs-agent
 
       # Building agent tars
       - GO111MODULE=auto
       - make release-agent 2>&1 | tee -a $BUILD_LOG
       - make generic-rpm-integrated 2>&1 | tee -a $BUILD_LOG
       - make -C ./ecs-agent/daemonimages/csidriver 2>&1 | tee -a $BUILD_LOG
+
+      # Build Windows executable
+      - make windows-docker-release 2>&1 | tee -a $BUILD_LOG
+
+      # Build Amazon Linux 2 RPMs
+      - make amazon-linux-rpm-integrated 2>&1 | tee -a $BUILD_LOG
       - ls
       
       # Rename artifacts for architecture

--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -52,14 +52,14 @@ phases:
       - echo $(pwd) 2>&1 | tee -a $BUILD_LOG
 
       # Path readjustment for codebuild testing with fork and setting GOPATH appropriately
-      - cd ../../../..
-      - export GOPATH=$GOPATH:$(pwd)
-      - cd src/github.com
-      - |
-        if [[ $GITHUBUSERNAME != "aws" ]] ; then
-          mv $GITHUBUSERNAME aws
-        fi
-      - cd aws/amazon-ecs-agent
+      #- cd ../../../..
+      #- export GOPATH=$GOPATH:$(pwd)
+      #- cd src/github.com
+      #- |
+      #  if [[ $GITHUBUSERNAME != "aws" ]] ; then
+      #    mv $GITHUBUSERNAME aws
+      #  fi
+      #- cd aws/amazon-ecs-agent
 
       # Building agent tars
       - GO111MODULE=auto


### PR DESCRIPTION
The windows and Amazon Linux make targets were successfully building locally, but not producing artifacts in the S3 bucket as expected. This change adjusts the placement for the new make targets to after/below the "GO111MODULE=auto" command, to ensure the global environment variable applies to the new targets. 

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
