### PR TITLE
Prevent the amazon-linux make target failing in CodeBuild

### DIFF
--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -6,6 +6,9 @@ env:
     GITHUBUSERNAME: ephylouise
 
 phases:
+  pre_build:
+    commands:
+      - git rev-parse HEAD > RELEASE_COMMIT
   install:
     commands:
       - architecture=""


### PR DESCRIPTION
The 'agent-dev-amd-stephy' CodeBuild job is failing to produce an Amazon Linux RPM. The build logs suggest the reason for failure is that the variable "RELEASE_COMMIT" in the Makefile file cannot be found. The variable looks like it was incorporated in the amazon-linux-rpm-integrated sources.tgz archive as a way to retrieve the commit hash from the latest release to provide information for the specific codebase used to build the rpm. 

As a temporary workaround, the following pre-build command has been added to the pr-build.yml file to assign the current commit hash to the variable. 

phases:
  pre_build:
    commands:
      - git rev-parse HEAD > RELEASE_COMMIT

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
