### PR TITLE
Go path and AL sources updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -394,7 +394,7 @@ amazon-linux-sources.tgz:
 	cp packaging/amazon-linux-ami-integrated/amazon-ecs-volume-plugin.conf amazon-ecs-volume-plugin.conf
 	cp packaging/amazon-linux-ami-integrated/amazon-ecs-volume-plugin.service amazon-ecs-volume-plugin.service
 	cp packaging/amazon-linux-ami-integrated/amazon-ecs-volume-plugin.socket amazon-ecs-volume-plugin.socket
-	tar -czf ./sources.tgz ecs-init scripts misc agent amazon-ecs-cni-plugins amazon-vpc-cni-plugins agent-container Makefile VERSION RELEASE_COMMIT
+	tar -czf ./sources.tgz ecs-init scripts misc agent amazon-ecs-cni-plugins amazon-vpc-cni-plugins agent-container Makefile VERSION GO_VERSION
 
 .amazon-linux-rpm-integrated-done: amazon-linux-sources.tgz
 	test -e SOURCES || ln -s . SOURCES

--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -51,14 +51,13 @@ phases:
       - echo $(pwd) 2>&1 | tee -a $BUILD_LOG
 
       # Path readjustment for codebuild testing with fork and setting GOPATH appropriately
-      #- cd ../../../..
-      #- export GOPATH=$GOPATH:$(pwd)
-      #- cd src/github.com
-      #- |
-      #  if [[ $GITHUBUSERNAME != "aws" ]] ; then
-      #    mv $GITHUBUSERNAME aws
-      #  fi
-      #- cd aws/amazon-ecs-agent
+      - cd ../../../..
+      - export GOPATH=$GOPATH:$(pwd)
+      - cd src/github.com
+      - |
+        if [[ $GITHUBUSERNAME != "aws" ]] ; then
+          ln -s $CODEBUILD_SRC_DIR /codebuild/output/src/github.com/aws/amazon-ecs-agent
+        fi
 
       # Building agent tars
       - GO111MODULE=auto


### PR DESCRIPTION
In pr-build.yml, the Go path adjustment code block is uncommented and modified to include a symlink instead of a "mv" command. 

In the Makefile, the amazon-linux-sources.tgz is modified to replace RELEASE_COMMIT with GO_VERSION to mirror the logic in the generic rpm make target. 

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
