### PR TITLE
Remove trailing space in original GOPATH if/then function

### DIFF
--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -55,9 +55,10 @@ phases:
       - export GOPATH=$GOPATH:$(pwd)
       - cd src/github.com
       - |
-        if [[ $GITHUBUSERNAME != "aws" ]] ; then
-          ln -s $CODEBUILD_SRC_DIR /codebuild/output/src/github.com/aws/amazon-ecs-agent
+        if [[ $GITHUBUSERNAME != "aws" ]]; then
+          mv $GITHUBUSERNAME aws
         fi
+      - cd aws/amazon-ecs-agent
 
       # Building agent tars
       - GO111MODULE=auto


### PR DESCRIPTION
The CodeBuild logs shows an error of "exit status 1" for the line within pr-build that includes an if/then function. There was a trailing space that has been removed here to test if that is the issue. 

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
