### PR TITLE
Correcting username syntax, capital letter

### DIFF
--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -3,7 +3,7 @@ version: 0.2
 env:
   variables:
     # Github username of the forked repo on which to make builds
-    GITHUBUSERNAME: ephylouise
+    GITHUBUSERNAME: Ephylouise
 
 phases:
   install:
@@ -56,7 +56,10 @@ phases:
       - cd ../../../..
       - export GOPATH=$GOPATH:$(pwd)
       - cd src/github.com
-      - mv $GITHUBUSERNAME aws
+      - |
+        if [[ $GITHUBUSERNAME != "aws" ]]; then
+          mv $GITHUBUSERNAME aws
+        fi
       - echo "GitHub Username = $GITHUBUSERNAME" 2>&1 | tee -a $BUILD_LOG
       - cd aws/amazon-ecs-agent
 


### PR DESCRIPTION
In the CodeBuild logs, the github user echo shows a syntax discrepency. I have changed "ephylouise" to "Ephylouise" and returned the original GO path adjustment code block to the file. 

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
