### PR TITLE
Troubleshooting Amazon-Linux make target errors in Codebuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -388,6 +388,7 @@ get-deps-init:
 
 amazon-linux-sources.tgz:
 	./scripts/update-version.sh
+	echo "Go version = $(GO_VERSION)"
 	cp packaging/amazon-linux-ami-integrated/ecs-agent.spec ecs-agent.spec
 	cp packaging/amazon-linux-ami-integrated/ecs.conf ecs.conf
 	cp packaging/amazon-linux-ami-integrated/ecs.service ecs.service

--- a/buildspecs/pr-build-ubuntu.yml
+++ b/buildspecs/pr-build-ubuntu.yml
@@ -3,7 +3,7 @@ version: 0.2
 env:
   variables:
     # Github username of the forked repo on which to make builds
-    GITHUBUSERNAME: aws
+    GITHUBUSERNAME: Ephylouise
 
 phases:
   install:

--- a/buildspecs/pr-build-ubuntu.yml
+++ b/buildspecs/pr-build-ubuntu.yml
@@ -33,7 +33,7 @@ phases:
       - cd ../../../..
       - cd src/github.com
       - |
-        if [[ $GITHUBUSERNAME != "aws" ]] ; then
+        if [ $GITHUBUSERNAME != "aws" ] ; then
           mv $GITHUBUSERNAME aws
         fi
       - cd aws/amazon-ecs-agent

--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -47,7 +47,7 @@ phases:
       - ECS_AGENT_TAR="ecs-agent-v${AGENT_VERSION}.tar"
       - CSI_DRIVER_TAR="./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver.tar"
       - ECS_AGENT_RPM="amazon-ecs-init-${AGENT_VERSION}-1.x86_64.rpm"
-      - AMZN_LINUX_2023_RPM="ecs-init-${AGENT_VERSION}-1.amzn2023int.x86_64.rpm"
+      - AMZN_LINUX_2023_RPM="ecs-init-${AGENT_VERSION}-1.amzn2023.x86_64.rpm"
       - echo $(pwd) 2>&1 | tee -a $BUILD_LOG
 
 
@@ -79,7 +79,7 @@ phases:
           ECS_AGENT_RPM="amazon-ecs-init-${AGENT_VERSION}-1.aarch64.rpm"
           ECS_AGENT_TAR="ecs-agent-arm64-v${AGENT_VERSION}.tar"
           CSI_DRIVER_TAR="./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver-arm64.tar"
-          AMZN_LINUX_2023_RPM="ecs-init-${AGENT_VERSION}-1.amzn2023int.aarch64.rpm"
+          AMZN_LINUX_2023_RPM="ecs-init-${AGENT_VERSION}-1.amzn2023.aarch64.rpm"
         fi
 
   post_build:

--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -47,7 +47,7 @@ phases:
       - ECS_AGENT_TAR="ecs-agent-v${AGENT_VERSION}.tar"
       - CSI_DRIVER_TAR="./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver.tar"
       - ECS_AGENT_RPM="amazon-ecs-init-${AGENT_VERSION}-1.x86_64.rpm"
-      - AMZN_LINUX_2_RPM="ecs-init-${AGENT_VERSION}-1.amzn2int.x86_64.rpm"
+      - AMZN_LINUX_2023_RPM="ecs-init-${AGENT_VERSION}-1.amzn2023int.x86_64.rpm"
       - echo $(pwd) 2>&1 | tee -a $BUILD_LOG
 
 
@@ -79,7 +79,7 @@ phases:
           ECS_AGENT_RPM="amazon-ecs-init-${AGENT_VERSION}-1.aarch64.rpm"
           ECS_AGENT_TAR="ecs-agent-arm64-v${AGENT_VERSION}.tar"
           CSI_DRIVER_TAR="./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver-arm64.tar"
-          AMZN_LINUX_2_RPM="ecs-init-${AGENT_VERSION}-1.amzn2int.aarch64.rpm"
+          AMZN_LINUX_2023_RPM="ecs-init-${AGENT_VERSION}-1.amzn2023int.aarch64.rpm"
         fi
 
   post_build:
@@ -89,7 +89,7 @@ artifacts:
   files:
     - $ECS_AGENT_TAR
     - $ECS_AGENT_RPM
-    - $AMZN_LINUX_2_RPM
+    - $AMZN_LINUX_2023_RPM
     - $BUILD_LOG
     - $CSI_DRIVER_TAR
   name: $CODEBUILD_RESOLVED_SOURCE_VERSION

--- a/packaging/amazon-linux-ami-integrated/ecs-agent.spec
+++ b/packaging/amazon-linux-ami-integrated/ecs-agent.spec
@@ -39,7 +39,7 @@ Source3:        amazon-ecs-volume-plugin.service
 Source4:        amazon-ecs-volume-plugin.socket
 Source5:        amazon-ecs-volume-plugin.conf
 
-BuildRequires:  golang >= 1.22.0
+# BuildRequires:  golang >= 1.22.0
 %if %{with systemd}
 BuildRequires:  systemd
 Requires:       systemd


### PR DESCRIPTION
Codebuild has failed to make the Amazon Linux RPM due to a go version discrepancy. 

The build log states:
"golang >= 1.22.0 is needed by ecs-init-1.84.0-1.amzn2023.x86_64"

The Makefile includes a GO_VERSION variable that points to the amazon-ecs-agent/GO_VERSION file that contains "1.22.3". So the go version should be > 1.22.0 during CodeBuilds. Adding the echo to troubleshoot.


### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
