### PR TITLE
Creating Buildspecs for Amazon Linux 2/2023

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -286,7 +286,7 @@ release-agent: get-cni-sources
 codebuild: .out-stamp
 	$(MAKE) release TARGET_OS="linux"
 	TARGET_OS="linux" ./scripts/local-save
-	$(MAKE) windows-docker-release
+	$(MAKE) docker-release TARGET_OS="windows"
 	TARGET_OS="windows" ./scripts/local-save
 
 netkitten:
@@ -399,7 +399,7 @@ get-deps-init:
 	GO111MODULE=on go install github.com/fzipp/gocyclo/cmd/gocyclo@v0.6.0
 	GO111MODULE=on go install honnef.co/go/tools/cmd/staticcheck@v0.4.0
 
-amazon-linux-sources.tgz:
+amazon-linux-sources.tgz: get-cni-sources
 	./scripts/update-version.sh
 	cp packaging/amazon-linux-ami-integrated/ecs-agent.spec ecs-agent.spec
 	cp packaging/amazon-linux-ami-integrated/ecs.conf ecs.conf

--- a/Makefile
+++ b/Makefile
@@ -110,15 +110,15 @@ docker-release: pause-container-release cni-plugins .out-stamp
 
 # Make a Windows release target
 windows-docker-release: .out-stamp
-    @docker build --build-arg GO_VERSION=${GO_VERSION} -f scripts/dockerfiles/Dockerfile.cleanbuild -t "amazon/amazon-ecs-agent-cleanbuild-windows:make" .
-    @docker run --net=none \
-            --env TARGET_OS="windows" \
-            --env GO111MODULE=auto \
-            --user "$(USERID)" \
-            --volume "$(PWD)/out:/out" \
-            --volume "$(PWD):/src/amazon-ecs-agent" \
-            --rm \
-            "amazon/amazon-ecs-agent-cleanbuild-windows:make"
+	@docker build --build-arg GO_VERSION=${GO_VERSION} -f scripts/dockerfiles/Dockerfile.cleanbuild -t "amazon/amazon-ecs-agent-cleanbuild-windows:make" .
+	@docker run --net=none \
+        --env TARGET_OS="windows" \
+        --env GO111MODULE=auto \
+        --user "$(USERID)" \
+        --volume "$(PWD)/out:/out" \
+        --volume "$(PWD):/src/amazon-ecs-agent" \
+        --rm \
+        "amazon/amazon-ecs-agent-cleanbuild-windows:make"
 
 
 # Legacy target : Release packages our agent into a "scratch" based dockerfile
@@ -241,7 +241,7 @@ build-ecs-cni-plugins:
 		-u "$(USERID)" \
 		-v "$(PWD)/out/amazon-ecs-cni-plugins:/go/src/github.com/aws/amazon-ecs-cni-plugins/bin/plugins" \
 		-v "$(ECS_CNI_REPOSITORY_SRC_DIR):/go/src/github.com/aws/amazon-ecs-cni-plugins" \
-		"amazon/amazon-ecs-build-ecs-cni-plugins:make"
+		"amazon/amazon-ecs-build-ecs-cni-plugins:make"		
 	@echo "Built amazon-ecs-cni-plugins successfully."
 
 build-vpc-cni-plugins:

--- a/Makefile
+++ b/Makefile
@@ -401,7 +401,6 @@ get-deps-init:
 
 amazon-linux-sources.tgz:
 	./scripts/update-version.sh
-	echo "Go version = $(GO_VERSION)"
 	cp packaging/amazon-linux-ami-integrated/ecs-agent.spec ecs-agent.spec
 	cp packaging/amazon-linux-ami-integrated/ecs.conf ecs.conf
 	cp packaging/amazon-linux-ami-integrated/ecs.service ecs.service

--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,19 @@ docker-release: pause-container-release cni-plugins .out-stamp
 		--rm \
 		"amazon/amazon-ecs-agent-${BUILD}:make"
 
+# Make a Windows release target
+windows-docker-release: .out-stamp
+    @docker build --build-arg GO_VERSION=${GO_VERSION} -f scripts/dockerfiles/Dockerfile.cleanbuild -t "amazon/amazon-ecs-agent-cleanbuild-windows:make" .
+    @docker run --net=none \
+            --env TARGET_OS="windows" \
+            --env GO111MODULE=auto \
+            --user "$(USERID)" \
+            --volume "$(PWD)/out:/out" \
+            --volume "$(PWD):/src/amazon-ecs-agent" \
+            --rm \
+            "amazon/amazon-ecs-agent-cleanbuild-windows:make"
+
+
 # Legacy target : Release packages our agent into a "scratch" based dockerfile
 release: certs docker-release
 	@./scripts/create-amazon-ecs-scratch
@@ -273,7 +286,7 @@ release-agent: get-cni-sources
 codebuild: .out-stamp
 	$(MAKE) release TARGET_OS="linux"
 	TARGET_OS="linux" ./scripts/local-save
-	$(MAKE) docker-release TARGET_OS="windows"
+	$(MAKE) windows-docker-release
 	TARGET_OS="windows" ./scripts/local-save
 
 netkitten:

--- a/buildspecs/pr-build-amzn2.yml
+++ b/buildspecs/pr-build-amzn2.yml
@@ -1,0 +1,70 @@
+version: 0.2
+
+env:
+  variables:
+    # Github username of the forked repo on which to make builds
+    GITHUBUSERNAME: Ephylouise
+
+phases:
+  install:
+    commands:
+      - architecture=""
+      # Same buildspec for different architectures - detect the architecture here and rename the artifacts accordingly
+      - case $(uname -m) in
+           x86_64)
+             architecture="amd64"
+           ;;
+           aarch64)
+             architecture="arm64"
+           ;;
+        esac
+
+      # Install GO to ensure version is up-to-date on OS
+      - sudo yum install golang -y
+
+      # Set appropriate environment variables
+      - export GOROOT=/usr/local/go
+      - export GOPATH=$HOME/go
+      - export GOBIN=$GOPATH/bin
+      - export PATH=$PATH:$GOROOT/bin:$GOBIN
+      - which go | tee -a $BUILD_LOG
+      - go version | tee -a $BUILD_LOG
+      
+  build:
+    commands:
+      - go version
+      - echo "build_id = $CODEBUILD_LOG_PATH" 2>&1 | tee -a $BUILD_LOG
+      - echo "Building agent image" 2>&1 | tee -a $BUILD_LOG
+      - AGENT_VERSION=$(cat VERSION)
+      - AMZN_LINUX_2_RPM="ecs-init-${AGENT_VERSION}-1.amzn2.x86_64.rpm"
+      - echo $(pwd) 2>&1 | tee -a $BUILD_LOG
+
+      # Path readjustment for codebuild testing with fork and setting GOPATH appropriately
+      - cd ../../../..
+      - export GOPATH=$GOPATH:$(pwd)
+      - cd src/github.com
+      - |
+        if [[ $GITHUBUSERNAME != "aws" ]]; then
+          mv $GITHUBUSERNAME aws
+        fi
+      - cd aws/amazon-ecs-agent
+
+      # Build Amazon Linux 2 RPM
+      - GO111MODULE=auto
+      - make amazon-linux-rpm-integrated 2>&1 | tee -a $BUILD_LOG
+      - ls
+      
+      # Rename artifacts for architecture
+      - |
+        if [[ $architecture == "arm64" ]] ; then
+          AMZN_LINUX_2023_RPM="ecs-init-${AGENT_VERSION}-1.amzn2.aarch64.rpm"
+        fi
+
+  post_build:
+    commands:
+
+artifacts:
+  files:
+    - $AMZN_LINUX_2_RPM
+  name: $CODEBUILD_RESOLVED_SOURCE_VERSION
+

--- a/buildspecs/pr-build-amzn2023.yml
+++ b/buildspecs/pr-build-amzn2023.yml
@@ -1,0 +1,70 @@
+version: 0.2
+
+env:
+  variables:
+    # Github username of the forked repo on which to make builds
+    GITHUBUSERNAME: Ephylouise
+    # Amazon Linux 2023 version
+    VERSION: 2023.4.20240611
+
+phases:
+  install:
+    commands:
+      - architecture=""
+      # Same buildspec for different architectures - detect the architecture here and rename the artifacts accordingly
+      - case $(uname -m) in
+           x86_64)
+             architecture="amd64"
+           ;;
+           aarch64)
+             architecture="arm64"
+           ;;
+        esac
+
+      # Install GO to ensure version is up-to-date on OS
+      - sudo dnf --releasever=$VERSION update
+      - sudo yum install golang -y
+
+      # Set appropriate environment variables
+      - export GOROOT=/usr/local/go
+      - export GOPATH=$HOME/go
+      - export GOBIN=$GOPATH/bin
+      - export PATH=$PATH:$GOROOT/bin:$GOBIN
+      - which go | tee -a $BUILD_LOG
+      - go version | tee -a $BUILD_LOG
+      
+  build:
+    commands:
+      - go version
+      - echo "build_id = $CODEBUILD_LOG_PATH" 2>&1 | tee -a $BUILD_LOG
+      - echo "Building agent image" 2>&1 | tee -a $BUILD_LOG
+      - AGENT_VERSION=$(cat VERSION)
+      - AMZN_LINUX_2023_RPM="ecs-init-${AGENT_VERSION}-1.amzn2023.x86_64.rpm"
+      - echo $(pwd) 2>&1 | tee -a $BUILD_LOG
+
+      # Path readjustment for codebuild testing with fork and setting GOPATH appropriately
+      - cd ../../../..
+      - export GOPATH=$GOPATH:$(pwd)
+      - cd src/github.com
+      - |
+        if [[ $GITHUBUSERNAME != "aws" ]]; then
+          mv $GITHUBUSERNAME aws
+        fi
+      - cd aws/amazon-ecs-agent
+
+      # Build Amazon Linux 2023 RPM
+      - GO111MODULE=auto
+      - make amazon-linux-rpm-integrated 2>&1 | tee -a $BUILD_LOG
+      - ls
+
+      # Rename artifacts for architecture
+      - |
+        if [[ $architecture == "arm64" ]] ; then
+          AMZN_LINUX_2023_RPM="ecs-init-${AGENT_VERSION}-1.amzn2023.aarch64.rpm"
+        fi
+
+artifacts:
+  files:
+    - $AMZN_LINUX_2_RPM
+  name: $CODEBUILD_RESOLVED_SOURCE_VERSION
+

--- a/buildspecs/pr-build-amzn2023.yml
+++ b/buildspecs/pr-build-amzn2023.yml
@@ -65,6 +65,5 @@ phases:
 
 artifacts:
   files:
-    - $AMZN_LINUX_2_RPM
+    - $AMZN_LINUX_2023_RPM
   name: $CODEBUILD_RESOLVED_SOURCE_VERSION
-

--- a/buildspecs/pr-build-amzn2023.yml
+++ b/buildspecs/pr-build-amzn2023.yml
@@ -22,7 +22,7 @@ phases:
         esac
 
       # Install GO to ensure version is up-to-date on OS
-      - sudo dnf --releasever=$VERSION update
+      - sudo dnf update -y
       - sudo yum install golang -y
 
       # Set appropriate environment variables

--- a/buildspecs/pr-build-amzn2023.yml
+++ b/buildspecs/pr-build-amzn2023.yml
@@ -5,7 +5,7 @@ env:
     # Github username of the forked repo on which to make builds
     GITHUBUSERNAME: Ephylouise
     # Amazon Linux 2023 version
-    VERSION: 2023.4.20240611
+    AL_VERSION: 2023.4.20240611
 
 phases:
   install:
@@ -21,8 +21,8 @@ phases:
            ;;
         esac
 
-      # Install GO to ensure version is up-to-date on OS
-      - sudo dnf --releasever=$VERSION update -y
+      # Install GO to ensure version is up-to-date on Target OS
+      - sudo dnf --releasever=$AL_VERSION update -y
       - sudo yum install golang -y
 
       # Set appropriate environment variables

--- a/buildspecs/pr-build-amzn2023.yml
+++ b/buildspecs/pr-build-amzn2023.yml
@@ -22,7 +22,7 @@ phases:
         esac
 
       # Install GO to ensure version is up-to-date on OS
-      - sudo dnf update -y
+      - sudo dnf --releasever=$VERSION update -y
       - sudo yum install golang -y
 
       # Set appropriate environment variables

--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -47,8 +47,7 @@ phases:
       - ECS_AGENT_TAR="ecs-agent-v${AGENT_VERSION}.tar"
       - CSI_DRIVER_TAR="./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver.tar"
       - ECS_AGENT_RPM="amazon-ecs-init-${AGENT_VERSION}-1.x86_64.rpm"
-      - AMZN_LINUX_2023_RPM="ecs-init-${AGENT_VERSION}-1.amzn2023.x86_64.rpm"
-      - WINDOWS_EXE="/out/amazon-ecs-agent.exe"
+      - WINDOWS_EXE="amazon-ecs-agent.exe"
       - echo $(pwd) 2>&1 | tee -a $BUILD_LOG
 
 
@@ -67,21 +66,12 @@ phases:
       # Building agent tars
       - GO111MODULE=auto
       - make release-agent 2>&1 | tee -a $BUILD_LOG
-      - make generic-rpm-integrated 2>&1 | tee -a $BUILD_LOG
+      #- make generic-rpm-integrated 2>&1 | tee -a $BUILD_LOG
       - make -C ./ecs-agent/daemonimages/csidriver 2>&1 | tee -a $BUILD_LOG
-
-      # Install GO to ensure version is up-to-date on OS for Amazon Linux 2023 RPM build
-      - |
-        if [[ $AMZN_LINUX_2023_RPM ]]; then
-          sudo dnf --releasever=$VERSION update -y
-          sudo yum install golang -y
-        fi
-
-      # Build Amazon Linux 2 RPM
-      - make amazon-linux-rpm-integrated 2>&1 | tee -a $BUILD_LOG
 
       # Build Windows executable
       - make docker-release TARGET_OS="windows" 2>&1 | tee -a $BUILD_LOG
+      - mv /out/out/amazon-ecs-agent.exe $WINDOWS_EXE
       - ls
 
       # Rename artifacts for architecture
@@ -92,7 +82,6 @@ phases:
           ECS_AGENT_RPM="amazon-ecs-init-${AGENT_VERSION}-1.aarch64.rpm"
           ECS_AGENT_TAR="ecs-agent-arm64-v${AGENT_VERSION}.tar"
           CSI_DRIVER_TAR="./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver-arm64.tar"
-          AMZN_LINUX_2023_RPM="ecs-init-${AGENT_VERSION}-1.amzn2023.aarch64.rpm"
         fi
 
   post_build:
@@ -102,7 +91,6 @@ artifacts:
   files:
     - $ECS_AGENT_TAR
     - $ECS_AGENT_RPM
-    - $AMZN_LINUX_2023_RPM
     - $WINDOWS_EXE
     - $BUILD_LOG
     - $CSI_DRIVER_TAR

--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -70,13 +70,18 @@ phases:
       - make generic-rpm-integrated 2>&1 | tee -a $BUILD_LOG
       - make -C ./ecs-agent/daemonimages/csidriver 2>&1 | tee -a $BUILD_LOG
 
+      # Install GO to ensure version is up-to-date on OS for Amazon Linux 2023 RPM build
+      - |
+        if [[ $AMZN_LINUX_2023_RPM ]]; then
+          sudo dnf --releasever=$VERSION update -y
+          sudo yum install golang -y
+        fi
+
       # Build Amazon Linux 2 RPM
       - make amazon-linux-rpm-integrated 2>&1 | tee -a $BUILD_LOG
 
       # Build Windows executable
-      - make windows-docker-release 2>&1 | tee -a $BUILD_LOG
-      - echo "The contents of the /out directory:"
-      - ls -l /out
+      - make docker-release TARGET_OS="windows" 2>&1 | tee -a $BUILD_LOG
       - ls
 
       # Rename artifacts for architecture

--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -44,10 +44,10 @@ phases:
       - echo "build_id = $CODEBUILD_LOG_PATH" 2>&1 | tee -a $BUILD_LOG
       - echo "Building agent image" 2>&1 | tee -a $BUILD_LOG
       - AGENT_VERSION=$(cat VERSION)
-      - ECS_AGENT_TAR="ecs-agent-v${AGENT_VERSION}.tar"
-      - CSI_DRIVER_TAR="./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver.tar"
-      - ECS_AGENT_RPM="amazon-ecs-init-${AGENT_VERSION}-1.x86_64.rpm"
-      - AMZN_LINUX_2023_RPM="ecs-init-${AGENT_VERSION}-1.amzn2023.x86_64.rpm"
+      #[ commented out for testing ]- ECS_AGENT_TAR="ecs-agent-v${AGENT_VERSION}.tar"
+      #[ commented out for testing ]- CSI_DRIVER_TAR="./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver.tar"
+      #[ commented out for testing ]- ECS_AGENT_RPM="amazon-ecs-init-${AGENT_VERSION}-1.x86_64.rpm"
+      #[ commented out for testing ]- AMZN_LINUX_2023_RPM="ecs-init-${AGENT_VERSION}-1.amzn2023.x86_64.rpm"
       - WINDOWS_EXE="amazon-ecs-agent.exe"
       - echo $(pwd) 2>&1 | tee -a $BUILD_LOG
 
@@ -66,35 +66,38 @@ phases:
 
       # Building agent tars
       - GO111MODULE=auto
-      - make release-agent 2>&1 | tee -a $BUILD_LOG
-      - make generic-rpm-integrated 2>&1 | tee -a $BUILD_LOG
+      #[ commented out for testing ]- make release-agent 2>&1 | tee -a $BUILD_LOG
+      #[ commented out for testing ]- make generic-rpm-integrated 2>&1 | tee -a $BUILD_LOG
+      #[ commented out for testing ]- make -C ./ecs-agent/daemonimages/csidriver 2>&1 | tee -a $BUILD_LOG
+
       # Build Amazon Linux 2 RPM
-      - make amazon-linux-rpm-integrated 2>&1 | tee -a $BUILD_LOG
+      #[ commented out for testing ]- make amazon-linux-rpm-integrated 2>&1 | tee -a $BUILD_LOG
+
       # Build Windows executable
       - make windows-docker-release 2>&1 | tee -a $BUILD_LOG
-      - make -C ./ecs-agent/daemonimages/csidriver 2>&1 | tee -a $BUILD_LOG
       - ls
+
       # Rename artifacts for architecture
-      - |
-        if [[ $architecture == "arm64" ]] ; then
-          mv $ECS_AGENT_TAR "ecs-agent-arm64-v${AGENT_VERSION}.tar"
-          mv $CSI_DRIVER_TAR "./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver-arm64.tar"
-          ECS_AGENT_RPM="amazon-ecs-init-${AGENT_VERSION}-1.aarch64.rpm"
-          ECS_AGENT_TAR="ecs-agent-arm64-v${AGENT_VERSION}.tar"
-          CSI_DRIVER_TAR="./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver-arm64.tar"
-          AMZN_LINUX_2023_RPM="ecs-init-${AGENT_VERSION}-1.amzn2023.aarch64.rpm"
-        fi
+      #[ commented out for testing ]- |
+        #[ commented out for testing ]if [[ $architecture == "arm64" ]] ; then
+          #[ commented out for testing ]mv $ECS_AGENT_TAR "ecs-agent-arm64-v${AGENT_VERSION}.tar"
+          #[ commented out for testing ]mv $CSI_DRIVER_TAR "./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver-arm64.tar"
+          #[ commented out for testing ]ECS_AGENT_RPM="amazon-ecs-init-${AGENT_VERSION}-1.aarch64.rpm"
+          #[ commented out for testing ]ECS_AGENT_TAR="ecs-agent-arm64-v${AGENT_VERSION}.tar"
+          #[ commented out for testing ]CSI_DRIVER_TAR="./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver-arm64.tar"
+          #[ commented out for testing ]AMZN_LINUX_2023_RPM="ecs-init-${AGENT_VERSION}-1.amzn2023.aarch64.rpm"
+        #[ commented out for testing ]fi
 
   post_build:
     commands:
 
 artifacts:
   files:
-    - $ECS_AGENT_TAR
-    - $ECS_AGENT_RPM
-    - $AMZN_LINUX_2023_RPM
+    #[ commented out for testing ]- $ECS_AGENT_TAR
+    #[ commented out for testing ]- $ECS_AGENT_RPM
+    #[ commented out for testing ]- $AMZN_LINUX_2023_RPM
     - $WINDOWS_EXE
-    - $BUILD_LOG
-    - $CSI_DRIVER_TAR
+    #[ commented out for testing ]- $BUILD_LOG
+    #[ commented out for testing ]- $CSI_DRIVER_TAR
   name: $CODEBUILD_RESOLVED_SOURCE_VERSION
 

--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -80,8 +80,8 @@ phases:
       - ls
 
       # Rename artifacts for architecture
-      -|
-        if [[ $architecture == "arm64" ]] ; then
+      - |
+        if [[ $architecture == "arm64" ]]; then
           mv $ECS_AGENT_TAR "ecs-agent-arm64-v${AGENT_VERSION}.tar"
           mv $CSI_DRIVER_TAR "./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver-arm64.tar"
           ECS_AGENT_RPM="amazon-ecs-init-${AGENT_VERSION}-1.aarch64.rpm"
@@ -89,6 +89,7 @@ phases:
           CSI_DRIVER_TAR="./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver-arm64.tar"
           AMZN_LINUX_2023_RPM="ecs-init-${AGENT_VERSION}-1.amzn2023.aarch64.rpm"
         fi
+
   post_build:
     commands:
 
@@ -101,4 +102,3 @@ artifacts:
     - $BUILD_LOG
     - $CSI_DRIVER_TAR
   name: $CODEBUILD_RESOLVED_SOURCE_VERSION
-

--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -89,7 +89,6 @@ phases:
           CSI_DRIVER_TAR="./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver-arm64.tar"
           AMZN_LINUX_2023_RPM="ecs-init-${AGENT_VERSION}-1.amzn2023.aarch64.rpm"
         fi
-
   post_build:
     commands:
 

--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -48,7 +48,7 @@ phases:
       #[ commented out for testing ]- CSI_DRIVER_TAR="./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver.tar"
       #[ commented out for testing ]- ECS_AGENT_RPM="amazon-ecs-init-${AGENT_VERSION}-1.x86_64.rpm"
       #[ commented out for testing ]- AMZN_LINUX_2023_RPM="ecs-init-${AGENT_VERSION}-1.amzn2023.x86_64.rpm"
-      - WINDOWS_EXE="amazon-ecs-agent.exe"
+      - WINDOWS_EXE="/out/amazon-ecs-agent.exe"
       - echo $(pwd) 2>&1 | tee -a $BUILD_LOG
 
 

--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -44,7 +44,7 @@ phases:
       - echo "build_id = $CODEBUILD_LOG_PATH" 2>&1 | tee -a $BUILD_LOG
       - echo "Building agent image" 2>&1 | tee -a $BUILD_LOG
       - AGENT_VERSION=$(cat VERSION)
-      #[ commented out for testing ]- ECS_AGENT_TAR="ecs-agent-v${AGENT_VERSION}.tar"
+      - ECS_AGENT_TAR="ecs-agent-v${AGENT_VERSION}.tar"
       #[ commented out for testing ]- CSI_DRIVER_TAR="./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver.tar"
       #[ commented out for testing ]- ECS_AGENT_RPM="amazon-ecs-init-${AGENT_VERSION}-1.x86_64.rpm"
       #[ commented out for testing ]- AMZN_LINUX_2023_RPM="ecs-init-${AGENT_VERSION}-1.amzn2023.x86_64.rpm"
@@ -66,7 +66,7 @@ phases:
 
       # Building agent tars
       - GO111MODULE=auto
-      #[ commented out for testing ]- make release-agent 2>&1 | tee -a $BUILD_LOG
+      - make release-agent 2>&1 | tee -a $BUILD_LOG
       #[ commented out for testing ]- make generic-rpm-integrated 2>&1 | tee -a $BUILD_LOG
       #[ commented out for testing ]- make -C ./ecs-agent/daemonimages/csidriver 2>&1 | tee -a $BUILD_LOG
 
@@ -75,15 +75,17 @@ phases:
 
       # Build Windows executable
       - make windows-docker-release 2>&1 | tee -a $BUILD_LOG
+      - echo "The contents of the /out directory:"
+      - ls -l /out
       - ls
 
       # Rename artifacts for architecture
-      #[ commented out for testing ]- |
-        #[ commented out for testing ]if [[ $architecture == "arm64" ]] ; then
-          #[ commented out for testing ]mv $ECS_AGENT_TAR "ecs-agent-arm64-v${AGENT_VERSION}.tar"
+      |
+        if [[ $architecture == "arm64" ]] ; then
+          mv $ECS_AGENT_TAR "ecs-agent-arm64-v${AGENT_VERSION}.tar"
           #[ commented out for testing ]mv $CSI_DRIVER_TAR "./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver-arm64.tar"
           #[ commented out for testing ]ECS_AGENT_RPM="amazon-ecs-init-${AGENT_VERSION}-1.aarch64.rpm"
-          #[ commented out for testing ]ECS_AGENT_TAR="ecs-agent-arm64-v${AGENT_VERSION}.tar"
+          ECS_AGENT_TAR="ecs-agent-arm64-v${AGENT_VERSION}.tar"
           #[ commented out for testing ]CSI_DRIVER_TAR="./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver-arm64.tar"
           #[ commented out for testing ]AMZN_LINUX_2023_RPM="ecs-init-${AGENT_VERSION}-1.amzn2023.aarch64.rpm"
         #[ commented out for testing ]fi
@@ -93,7 +95,7 @@ phases:
 
 artifacts:
   files:
-    #[ commented out for testing ]- $ECS_AGENT_TAR
+    - $ECS_AGENT_TAR
     #[ commented out for testing ]- $ECS_AGENT_RPM
     #[ commented out for testing ]- $AMZN_LINUX_2023_RPM
     - $WINDOWS_EXE

--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -45,9 +45,9 @@ phases:
       - echo "Building agent image" 2>&1 | tee -a $BUILD_LOG
       - AGENT_VERSION=$(cat VERSION)
       - ECS_AGENT_TAR="ecs-agent-v${AGENT_VERSION}.tar"
-      #[ commented out for testing ]- CSI_DRIVER_TAR="./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver.tar"
-      #[ commented out for testing ]- ECS_AGENT_RPM="amazon-ecs-init-${AGENT_VERSION}-1.x86_64.rpm"
-      #[ commented out for testing ]- AMZN_LINUX_2023_RPM="ecs-init-${AGENT_VERSION}-1.amzn2023.x86_64.rpm"
+      - CSI_DRIVER_TAR="./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver.tar"
+      - ECS_AGENT_RPM="amazon-ecs-init-${AGENT_VERSION}-1.x86_64.rpm"
+      - AMZN_LINUX_2023_RPM="ecs-init-${AGENT_VERSION}-1.amzn2023.x86_64.rpm"
       - WINDOWS_EXE="/out/amazon-ecs-agent.exe"
       - echo $(pwd) 2>&1 | tee -a $BUILD_LOG
 
@@ -67,11 +67,11 @@ phases:
       # Building agent tars
       - GO111MODULE=auto
       - make release-agent 2>&1 | tee -a $BUILD_LOG
-      #[ commented out for testing ]- make generic-rpm-integrated 2>&1 | tee -a $BUILD_LOG
-      #[ commented out for testing ]- make -C ./ecs-agent/daemonimages/csidriver 2>&1 | tee -a $BUILD_LOG
+      - make generic-rpm-integrated 2>&1 | tee -a $BUILD_LOG
+      - make -C ./ecs-agent/daemonimages/csidriver 2>&1 | tee -a $BUILD_LOG
 
       # Build Amazon Linux 2 RPM
-      #[ commented out for testing ]- make amazon-linux-rpm-integrated 2>&1 | tee -a $BUILD_LOG
+      - make amazon-linux-rpm-integrated 2>&1 | tee -a $BUILD_LOG
 
       # Build Windows executable
       - make windows-docker-release 2>&1 | tee -a $BUILD_LOG
@@ -80,15 +80,15 @@ phases:
       - ls
 
       # Rename artifacts for architecture
-      |
+      -|
         if [[ $architecture == "arm64" ]] ; then
           mv $ECS_AGENT_TAR "ecs-agent-arm64-v${AGENT_VERSION}.tar"
-          #[ commented out for testing ]mv $CSI_DRIVER_TAR "./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver-arm64.tar"
-          #[ commented out for testing ]ECS_AGENT_RPM="amazon-ecs-init-${AGENT_VERSION}-1.aarch64.rpm"
+          mv $CSI_DRIVER_TAR "./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver-arm64.tar"
+          ECS_AGENT_RPM="amazon-ecs-init-${AGENT_VERSION}-1.aarch64.rpm"
           ECS_AGENT_TAR="ecs-agent-arm64-v${AGENT_VERSION}.tar"
-          #[ commented out for testing ]CSI_DRIVER_TAR="./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver-arm64.tar"
-          #[ commented out for testing ]AMZN_LINUX_2023_RPM="ecs-init-${AGENT_VERSION}-1.amzn2023.aarch64.rpm"
-        #[ commented out for testing ]fi
+          CSI_DRIVER_TAR="./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver-arm64.tar"
+          AMZN_LINUX_2023_RPM="ecs-init-${AGENT_VERSION}-1.amzn2023.aarch64.rpm"
+        fi
 
   post_build:
     commands:
@@ -96,10 +96,10 @@ phases:
 artifacts:
   files:
     - $ECS_AGENT_TAR
-    #[ commented out for testing ]- $ECS_AGENT_RPM
-    #[ commented out for testing ]- $AMZN_LINUX_2023_RPM
+    - $ECS_AGENT_RPM
+    - $AMZN_LINUX_2023_RPM
     - $WINDOWS_EXE
-    #[ commented out for testing ]- $BUILD_LOG
-    #[ commented out for testing ]- $CSI_DRIVER_TAR
+    - $BUILD_LOG
+    - $CSI_DRIVER_TAR
   name: $CODEBUILD_RESOLVED_SOURCE_VERSION
 

--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -52,7 +52,6 @@ phases:
 
 
       # Path readjustment for codebuild testing with fork and setting GOPATH appropriately
-      - echo "GitHub Username = $GITHUBUSERNAME" 2>&1 | tee -a $BUILD_LOG
       - cd ../../../..
       - export GOPATH=$GOPATH:$(pwd)
       - cd src/github.com
@@ -60,7 +59,6 @@ phases:
         if [[ $GITHUBUSERNAME != "aws" ]]; then
           mv $GITHUBUSERNAME aws
         fi
-      - echo "GitHub Username = $GITHUBUSERNAME" 2>&1 | tee -a $BUILD_LOG
       - cd aws/amazon-ecs-agent
 
       # Building agent tars

--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -48,6 +48,7 @@ phases:
       - CSI_DRIVER_TAR="./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver.tar"
       - ECS_AGENT_RPM="amazon-ecs-init-${AGENT_VERSION}-1.x86_64.rpm"
       - AMZN_LINUX_2023_RPM="ecs-init-${AGENT_VERSION}-1.amzn2023.x86_64.rpm"
+      - WINDOWS_EXE="amazon-ecs-agent.exe"
       - echo $(pwd) 2>&1 | tee -a $BUILD_LOG
 
 
@@ -69,6 +70,8 @@ phases:
       - make generic-rpm-integrated 2>&1 | tee -a $BUILD_LOG
       # Build Amazon Linux 2 RPM
       - make amazon-linux-rpm-integrated 2>&1 | tee -a $BUILD_LOG
+      # Build Windows executable
+      - make windows-docker-release 2>&1 | tee -a $BUILD_LOG
       - make -C ./ecs-agent/daemonimages/csidriver 2>&1 | tee -a $BUILD_LOG
       - ls
       # Rename artifacts for architecture
@@ -90,6 +93,7 @@ artifacts:
     - $ECS_AGENT_TAR
     - $ECS_AGENT_RPM
     - $AMZN_LINUX_2023_RPM
+    - $WINDOWS_EXE
     - $BUILD_LOG
     - $CSI_DRIVER_TAR
   name: $CODEBUILD_RESOLVED_SOURCE_VERSION

--- a/packaging/amazon-linux-ami-integrated/ecs-agent.spec
+++ b/packaging/amazon-linux-ami-integrated/ecs-agent.spec
@@ -39,7 +39,7 @@ Source3:        amazon-ecs-volume-plugin.service
 Source4:        amazon-ecs-volume-plugin.socket
 Source5:        amazon-ecs-volume-plugin.conf
 
-# BuildRequires:  golang >= 1.22.0
+BuildRequires:  golang >= 1.22.0
 %if %{with systemd}
 BuildRequires:  systemd
 Requires:       systemd


### PR DESCRIPTION
### Creating Buildspecs for Amazon Linux 2/2023

To manage the dependency of the Go version, which needs to be 1.22.0 or greater (as defined in ecs-agent.spec for Amazon Linux builds), Go specifications must be handled in the buildspec files. AL2 uses the YUM package manager and AL2023 uses the DNF package manager. Therefore, the code to manage the Go dependency needs to be different. To account for the dependencies of Amazon Linux versions, a version-specific buildspec file is needed for each.

### Externally creating 2 new CodeBuild projects as well.

The operating system and image defined in CodeBuild job configurations determine the possible artifacts built by the project. The dev-amd project will not be able to make both Amazon Linux versions.

During testing, it was discovered that Amazon Linux 2023 can be built on agent-dev-amd CodeBuild project because the image is aws/codebuild/amazonlinux2-x86_64-standard:5.0, which can build Amazon Linux 2023 (despite the misnomer of 'linux2'). However, to build AL2, the image ending in "standard:4.0" should be used. Only one image can be defined for each CodeBuild job. To keep projects decoupled, instead of lumping amzn2023 in with the "generic" RPM and agent.tar, it might be best to create 2 new projects.

Two CodeBuild jobs called 'agent-dev-amzn2-stephy' and 'agent-dev-amzn2023-stephy' have been created with their respective and specific image requirements.

### Licensing
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.