### PR TITLE
Building Amazon Linux ARM

### DIFF
--- a/buildspecs/pr-build-amzn2.yml
+++ b/buildspecs/pr-build-amzn2.yml
@@ -60,7 +60,7 @@ phases:
       # Rename artifacts for architecture
       - |
         if [[ $architecture == "arm64" ]] ; then
-          AMZN_LINUX_2023_RPM="ecs-init-${AGENT_VERSION}-1.amzn2.aarch64.rpm"
+          AMZN_LINUX_2_RPM="ecs-init-${AGENT_VERSION}-1.amzn2.aarch64.rpm"
         fi
 
   post_build:

--- a/buildspecs/pr-build-amzn2.yml
+++ b/buildspecs/pr-build-amzn2.yml
@@ -25,11 +25,14 @@ phases:
 
       # Set evironment GOROOT based on architecture
       - |
-        if [[ "$(uname -m)" == "x86_64" ]]; then
-          export GOROOT=/usr/bin/go
+        if [[ $architecture == "amd64" ]]; then
+          export GOROOT=/usr
         else
-          export GOROOT=/usr/local/go/bin/go
+          export GOROOT=/usr/local/go
         fi
+      - export GOPATH=$HOME/go
+      - export GOBIN=$GOPATH/bin
+      - export PATH=$PATH:$GOROOT/bin:$GOBIN
       - which go | tee -a $BUILD_LOG
       - go version | tee -a $BUILD_LOG
       

--- a/buildspecs/pr-build-amzn2.yml
+++ b/buildspecs/pr-build-amzn2.yml
@@ -20,19 +20,19 @@ phases:
         esac
 
       # Install GO to ensure version is up-to-date on OS
-      - sudo rm -rf "/root/.goenv"
       - sudo yum install golang -y
 
       # Set evironment GOROOT based on architecture
-      - |
-        if [[ $architecture == "amd64" ]]; then
-          export GOROOT=/usr
-        else
-          export GOROOT=/usr/local/go
-        fi
-      - export GOPATH=$HOME/go
-      - export GOBIN=$GOPATH/bin
-      - export PATH=$PATH:$GOROOT/bin:$GOBIN
+      #- |
+      #  if [[ $architecture == "amd64" ]]; then
+      #    export GOROOT=/usr
+      #  else
+      #    export GOROOT=/usr/local/go
+      #  fi
+      #- export GOPATH=$HOME/go
+      #- export GOBIN=$GOPATH/bin
+      #- export PATH=$PATH:$GOROOT/bin:$GOBIN
+      - sudo rm -rf "/root/.goenv"
       - which go | tee -a $BUILD_LOG
       - go version | tee -a $BUILD_LOG
       

--- a/buildspecs/pr-build-amzn2.yml
+++ b/buildspecs/pr-build-amzn2.yml
@@ -27,6 +27,9 @@ phases:
       #- export GOPATH=$HOME/go
       #- export GOBIN=$GOPATH/bin
       #- export PATH=$PATH:$GOROOT/bin:$GOBIN
+
+      # Remove goenv installed version
+      - sudo rm -rf "/root/.goenv"
       - which go | tee -a $BUILD_LOG
       - go version | tee -a $BUILD_LOG
       

--- a/buildspecs/pr-build-amzn2.yml
+++ b/buildspecs/pr-build-amzn2.yml
@@ -24,11 +24,12 @@ phases:
       - sudo yum install golang -y
 
       # Set evironment GOROOT based on architecture
-      - if [[ "$(uname -m)" == "x86_64" ]]; then
+      - |
+        if [[ "$(uname -m)" == "x86_64" ]]; then
           export GOROOT=/usr/bin/go
         else
           export GOROOT=/usr/local/go/bin/go
-            fi
+        fi
       - which go | tee -a $BUILD_LOG
       - go version | tee -a $BUILD_LOG
       

--- a/buildspecs/pr-build-amzn2.yml
+++ b/buildspecs/pr-build-amzn2.yml
@@ -20,16 +20,15 @@ phases:
         esac
 
       # Install GO to ensure version is up-to-date on OS
+      - sudo rm -rf "/root/.goenv"
       - sudo yum install golang -y
 
-      # Set appropriate environment variables
-      #- export GOROOT=/usr/local/go
-      #- export GOPATH=$HOME/go
-      #- export GOBIN=$GOPATH/bin
-      #- export PATH=$PATH:$GOROOT/bin:$GOBIN
-
-      # Remove goenv installed version
-      - sudo rm -rf "/root/.goenv"
+      # Set evironment GOROOT based on architecture
+      - if [[ "$(uname -m)" == "x86_64" ]]; then
+          export GOROOT=/usr/bin/go
+        else
+          export GOROOT=/usr/local/go/bin/go
+            fi
       - which go | tee -a $BUILD_LOG
       - go version | tee -a $BUILD_LOG
       

--- a/buildspecs/pr-build-amzn2.yml
+++ b/buildspecs/pr-build-amzn2.yml
@@ -21,19 +21,8 @@ phases:
 
       # Install GO to ensure version is up-to-date on OS
       - sudo yum install golang -y
-
-      # Set evironment GOROOT based on architecture
-      #- |
-      #  if [[ $architecture == "amd64" ]]; then
-      #    export GOROOT=/usr
-      #  else
-      #    export GOROOT=/usr/local/go
-      #  fi
-      #- export GOPATH=$HOME/go
-      #- export GOBIN=$GOPATH/bin
-      #- export PATH=$PATH:$GOROOT/bin:$GOBIN
-      - sudo rm -rf /root/.goenv
-      - sudo rm -rf /usr/local/go/bin/go
+      - sudo rm -rf /root/.goenv # removes default goroot for AMD build
+      - sudo rm -rf /usr/local/go/bin/go # removes default goroot for ARM build
       - which go | tee -a $BUILD_LOG
       - go version | tee -a $BUILD_LOG
       

--- a/buildspecs/pr-build-amzn2.yml
+++ b/buildspecs/pr-build-amzn2.yml
@@ -32,7 +32,8 @@ phases:
       #- export GOPATH=$HOME/go
       #- export GOBIN=$GOPATH/bin
       #- export PATH=$PATH:$GOROOT/bin:$GOBIN
-      - sudo rm -rf "/root/.goenv"
+      - sudo rm -rf /root/.goenv
+      - sudo rm -rf /usr/local/go/bin/go
       - which go | tee -a $BUILD_LOG
       - go version | tee -a $BUILD_LOG
       

--- a/buildspecs/pr-build-amzn2.yml
+++ b/buildspecs/pr-build-amzn2.yml
@@ -23,10 +23,10 @@ phases:
       - sudo yum install golang -y
 
       # Set appropriate environment variables
-      - export GOROOT=/usr/local/go
-      - export GOPATH=$HOME/go
-      - export GOBIN=$GOPATH/bin
-      - export PATH=$PATH:$GOROOT/bin:$GOBIN
+      #- export GOROOT=/usr/local/go
+      #- export GOPATH=$HOME/go
+      #- export GOBIN=$GOPATH/bin
+      #- export PATH=$PATH:$GOROOT/bin:$GOBIN
       - which go | tee -a $BUILD_LOG
       - go version | tee -a $BUILD_LOG
       

--- a/buildspecs/pr-build-amzn2023.yml
+++ b/buildspecs/pr-build-amzn2023.yml
@@ -26,10 +26,8 @@ phases:
       - sudo yum install golang -y
 
       # Set appropriate environment variables
-      - export GOROOT=/usr/local/go
-      - export GOPATH=$HOME/go
-      - export GOBIN=$GOPATH/bin
-      - export PATH=$PATH:$GOROOT/bin:$GOBIN
+      # Remove goenv installed version
+      - sudo rm -rf "/root/.goenv"
       - which go | tee -a $BUILD_LOG
       - go version | tee -a $BUILD_LOG
       

--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -69,6 +69,7 @@ phases:
 
       # Build Windows executable
       - make docker-release TARGET_OS="windows" 2>&1 | tee -a $BUILD_LOG
+      - cp ./out/amazon-ecs-agent.exe $CODEBUILD_SRC_DIR/
       - echo $(find . -name amazon-ecs-agent.exe)
       - ls
 

--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -70,7 +70,7 @@ phases:
       # Build Windows executable
       - make docker-release TARGET_OS="windows" 2>&1 | tee -a $BUILD_LOG
       - echo $(find . -name amazon-ecs-agent.exe)
-      - mv /out/amazon-ecs-agent.exe $CODEBUILD_SRC_DIR/
+      - mv ./out/amazon-ecs-agent.exe $CODEBUILD_SRC_DIR/
       - ls
 
       # Rename artifacts for architecture

--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -69,7 +69,7 @@ phases:
 
       # Build Windows executable
       - make docker-release TARGET_OS="windows" 2>&1 | tee -a $BUILD_LOG
-      - cp ./out/amazon-ecs-agent.exe $CODEBUILD_SRC_DIR/
+      - ls -l ./out
       - echo $(find . -name amazon-ecs-agent.exe)
       - ls
 

--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -69,7 +69,7 @@ phases:
 
       # Build Windows executable
       - make docker-release TARGET_OS="windows" 2>&1 | tee -a $BUILD_LOG
-      - mv /out/out/amazon-ecs-agent.exe $WINDOWS_EXE
+      - mv /out/amazon-ecs-agent.exe $WINDOWS_EXE
       - ls
 
       # Rename artifacts for architecture

--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -63,33 +63,34 @@ phases:
 
       # Building agent tars
       - GO111MODULE=auto
-      - make release-agent 2>&1 | tee -a $BUILD_LOG
+      #- make release-agent 2>&1 | tee -a $BUILD_LOG
       #- make generic-rpm-integrated 2>&1 | tee -a $BUILD_LOG
-      - make -C ./ecs-agent/daemonimages/csidriver 2>&1 | tee -a $BUILD_LOG
+      #- make -C ./ecs-agent/daemonimages/csidriver 2>&1 | tee -a $BUILD_LOG
 
       # Build Windows executable
       - make docker-release TARGET_OS="windows" 2>&1 | tee -a $BUILD_LOG
       - echo $(find . -name amazon-ecs-agent.exe)
+      - mv /out/amazon-ecs-agent.exe $CODEBUILD_SRC_DIR/
       - ls
 
       # Rename artifacts for architecture
-      - |
-        if [[ $architecture == "arm64" ]]; then
-          mv $ECS_AGENT_TAR "ecs-agent-arm64-v${AGENT_VERSION}.tar"
-          mv $CSI_DRIVER_TAR "./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver-arm64.tar"
-          ECS_AGENT_RPM="amazon-ecs-init-${AGENT_VERSION}-1.aarch64.rpm"
-          ECS_AGENT_TAR="ecs-agent-arm64-v${AGENT_VERSION}.tar"
-          CSI_DRIVER_TAR="./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver-arm64.tar"
-        fi
+      #- |
+      #  if [[ $architecture == "arm64" ]]; then
+      #    mv $ECS_AGENT_TAR "ecs-agent-arm64-v${AGENT_VERSION}.tar"
+      #    mv $CSI_DRIVER_TAR "./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver-arm64.tar"
+      #    ECS_AGENT_RPM="amazon-ecs-init-${AGENT_VERSION}-1.aarch64.rpm"
+      #    ECS_AGENT_TAR="ecs-agent-arm64-v${AGENT_VERSION}.tar"
+      #    CSI_DRIVER_TAR="./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver-arm64.tar"
+      #  fi
 
   post_build:
     commands:
 
 artifacts:
   files:
-    - $ECS_AGENT_TAR
-    - $ECS_AGENT_RPM
+    #- $ECS_AGENT_TAR
+    #- $ECS_AGENT_RPM
     - $WINDOWS_EXE
-    - $BUILD_LOG
-    - $CSI_DRIVER_TAR
+    #- $BUILD_LOG
+    #- $CSI_DRIVER_TAR
   name: $CODEBUILD_RESOLVED_SOURCE_VERSION

--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -70,7 +70,6 @@ phases:
       # Build Windows executable
       - make docker-release TARGET_OS="windows" 2>&1 | tee -a $BUILD_LOG
       - echo $(find . -name amazon-ecs-agent.exe)
-      - mv ./out/amazon-ecs-agent.exe $CODEBUILD_SRC_DIR/
       - ls
 
       # Rename artifacts for architecture

--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -69,7 +69,7 @@ phases:
 
       # Build Windows executable
       - make docker-release TARGET_OS="windows" 2>&1 | tee -a $BUILD_LOG
-      - mv /out/amazon-ecs-agent.exe $WINDOWS_EXE
+      - echo $(find . -name amazon-ecs-agent.exe)
       - ls
 
       # Rename artifacts for architecture


### PR DESCRIPTION
Working on getting Amazon Linux RPM to build with CodeBuild webhook.

The CodeBuild configurations include an environment image that differs between versions.

Image options:
amazonlinux2-aarch64-standard:2.0 (Amazon Linux 2 ARM)
amazonlinux2-aarch64-standard:3.0 (Amazon-Linux 2023, Generic ARM RPM)
 amazonlinux2-x86_64-standard:4.0 (Amazon Linux 2 AMD)
amazonlinux2-x86_64-standard:5.0 (Amazon-Linux 2023, and Generic AMD RPM)

This PR is editing buildspecs to accommodate the 4 new CodeBuild projects:
amzn2-amd
amzn2-arm
amzn2023-amd
amzn2023-arm

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
