### PR TITLE
Restore order of make targets in pr-build.yml

### DIFF
--- a/buildspecs/pr-build-amzn.yml
+++ b/buildspecs/pr-build-amzn.yml
@@ -3,7 +3,7 @@ version: 0.2
 env:
   variables:
     # Github username of the forked repo on which to make builds
-    GITHUBUSERNAME: aws
+    GITHUBUSERNAME: Ephylouise
 
 phases:
   install:

--- a/buildspecs/pr-build-ubuntu.yml
+++ b/buildspecs/pr-build-ubuntu.yml
@@ -3,7 +3,7 @@ version: 0.2
 env:
   variables:
     # Github username of the forked repo on which to make builds
-    GITHUBUSERNAME: aws
+    GITHUBUSERNAME: Ephylouise
 
 phases:
   install:

--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -3,7 +3,7 @@ version: 0.2
 env:
   variables:
     # Github username of the forked repo on which to make builds
-    GITHUBUSERNAME: aws
+    GITHUBUSERNAME: Ephylouise
 
 phases:
   install:

--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -62,8 +62,8 @@ phases:
       # Building agent tars
       - GO111MODULE=auto
       - make release-agent 2>&1 | tee -a $BUILD_LOG
-      - make -C ./ecs-agent/daemonimages/csidriver 2>&1 | tee -a $BUILD_LOG
       - make generic-rpm-integrated 2>&1 | tee -a $BUILD_LOG
+      - make -C ./ecs-agent/daemonimages/csidriver 2>&1 | tee -a $BUILD_LOG
 
       # Build Windows executable
       - make docker-release TARGET_OS="windows" 2>&1 | tee -a $BUILD_LOG
@@ -88,8 +88,8 @@ phases:
 artifacts:
   files:
     - $ECS_AGENT_TAR
-    - $CSI_DRIVER_TAR
     - $ECS_AGENT_RPM
-    - $WINDOWS_EXE
     - $BUILD_LOG
+    - $CSI_DRIVER_TAR
+    - $WINDOWS_EXE
   name: $CODEBUILD_RESOLVED_SOURCE_VERSION


### PR DESCRIPTION
Reorder the make targets in pr-build.yml

Commits directly to dev-stephyr were made as well:
Use the os-release file to detect Amazon Linux version
Add new make target in Makefile for Amazon Linux to avoid changes to koji buils that utilize amazon-rpm-integrated
Change the name of the AL target to match Makefile 

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
