### PR TITLE
Updating CloudFormation Stack template with new CodeBuild project configurations. 

### DIFF
--- a/build-infrastructure/codebuild-devbuild-stack.yml
+++ b/build-infrastructure/codebuild-devbuild-stack.yml
@@ -235,6 +235,8 @@ Resources:
               Pattern: '3102848' # YashdalfTheGray
         Webhook: true
       Visibility: PRIVATE
+
+  # Creates a CodeBuild project for Amazon Linux 2 ARM    
   Amzn2ArmProject:
     Type: 'AWS::CodeBuild::Project'
     Properties:
@@ -258,7 +260,7 @@ Resources:
       QueuedTimeoutInMinutes: 60
       ServiceRole: !Ref ServiceRoleAmzn2Arm
       Source:
-        BuildSpec: buildspecs/pr-build.yml
+        BuildSpec: buildspecs/pr-build-amzn.yml
         Location: !Ref GithubFullRepoName
         Type: GITHUB
       TimeoutInMinutes: 60
@@ -286,6 +288,7 @@ Resources:
         Webhook: true
       Visibility: PRIVATE
 
+  # ACreates a CodeBuild project for Amazon Linux 2 AMD
   Amzn2AmdProject:
     Type: 'AWS::CodeBuild::Project'
     Properties:
@@ -309,7 +312,7 @@ Resources:
       QueuedTimeoutInMinutes: 60
       ServiceRole: !Ref ServiceRoleAmzn2Amd
       Source:
-        BuildSpec: buildspecs/pr-build.yml
+        BuildSpec: buildspecs/pr-build-amzn.yml
         Location: !Ref GithubFullRepoName
         Type: GITHUB
       TimeoutInMinutes: 60
@@ -337,6 +340,7 @@ Resources:
         Webhook: true
       Visibility: PRIVATE
 
+  # Creates a CodeBuild project for Amazon Linux 2023 ARM
   Amzn2023ArmProject:
     Type: 'AWS::CodeBuild::Project'
     Properties:
@@ -360,7 +364,7 @@ Resources:
       QueuedTimeoutInMinutes: 60
       ServiceRole: !Ref ServiceRoleAmzn2023Arm
       Source:
-        BuildSpec: buildspecs/pr-build.yml
+        BuildSpec: buildspecs/pr-build-amzn.yml
         Location: !Ref GithubFullRepoName
         Type: GITHUB
       TimeoutInMinutes: 60
@@ -388,6 +392,7 @@ Resources:
         Webhook: true
       Visibility: PRIVATE
 
+  # Creates a CodeBuild project for Amazon Linux 2023 AMD
   Amzn2023AmdProject:
     Type: 'AWS::CodeBuild::Project'
     Properties:
@@ -411,7 +416,7 @@ Resources:
       QueuedTimeoutInMinutes: 60
       ServiceRole: !Ref ServiceRoleAmzn2023Amd
       Source:
-        BuildSpec: buildspecs/pr-build.yml
+        BuildSpec: buildspecs/pr-build-amzn.yml
         Location: !Ref GithubFullRepoName
         Type: GITHUB
       TimeoutInMinutes: 60

--- a/build-infrastructure/codebuild-devbuild-stack.yml
+++ b/build-infrastructure/codebuild-devbuild-stack.yml
@@ -54,19 +54,19 @@ Resources:
         # so they have to be listed separately
         FilterGroups:
           - - Type: EVENT
-              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED'
+              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED,PULL_REQUEST_MERGED'
             - Type: BASE_REF
               Pattern: !Sub '^${GithubBranchName}$'
             - Type: ACTOR_ACCOUNT_ID
               Pattern: '5080306' # prateekchaudhry
           - - Type: EVENT
-              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED'
+              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED,PULL_REQUEST_MERGED'
             - Type: BASE_REF
               Pattern: !Sub '^${GithubBranchName}$'
             - Type: ACTOR_ACCOUNT_ID
               Pattern: '4751028' # fierlion
           - - Type: EVENT
-              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED'
+              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED,PULL_REQUEST_MERGED'
             - Type: BASE_REF
               Pattern: !Sub '^${GithubBranchName}$'
             - Type: ACTOR_ACCOUNT_ID
@@ -108,19 +108,19 @@ Resources:
         # so they have to be listed separately
         FilterGroups:
           - - Type: EVENT
-              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED'
+              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED,PULL_REQUEST_MERGED'
             - Type: BASE_REF
               Pattern: !Sub '^${GithubBranchName}$'
             - Type: ACTOR_ACCOUNT_ID
               Pattern: '5080306' # prateekchaudhry
           - - Type: EVENT
-              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED'
+              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED,PULL_REQUEST_MERGED'
             - Type: BASE_REF
               Pattern: !Sub '^${GithubBranchName}$'
             - Type: ACTOR_ACCOUNT_ID
               Pattern: '4751028' # fierlion
           - - Type: EVENT
-              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED'
+              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED,PULL_REQUEST_MERGED'
             - Type: BASE_REF
               Pattern: !Sub '^${GithubBranchName}$'
             - Type: ACTOR_ACCOUNT_ID
@@ -162,19 +162,19 @@ Resources:
         # so they have to be listed separately
         FilterGroups:
           - - Type: EVENT
-              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED'
+              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED,PULL_REQUEST_MERGED'
             - Type: BASE_REF
               Pattern: !Sub '^${GithubBranchName}$'
             - Type: ACTOR_ACCOUNT_ID
               Pattern: '5080306' # prateekchaudhry
           - - Type: EVENT
-              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED'
+              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED,PULL_REQUEST_MERGED'
             - Type: BASE_REF
               Pattern: !Sub '^${GithubBranchName}$'
             - Type: ACTOR_ACCOUNT_ID
               Pattern: '4751028' # fierlion
           - - Type: EVENT
-              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED'
+              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED,PULL_REQUEST_MERGED'
             - Type: BASE_REF
               Pattern: !Sub '^${GithubBranchName}$'
             - Type: ACTOR_ACCOUNT_ID
@@ -216,19 +216,19 @@ Resources:
         # so they have to be listed separately
         FilterGroups:
           - - Type: EVENT
-              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED'
+              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED,PULL_REQUEST_MERGED'
             - Type: BASE_REF
               Pattern: !Sub '^${GithubBranchName}$'
             - Type: ACTOR_ACCOUNT_ID
               Pattern: '5080306' # prateekchaudhry
           - - Type: EVENT
-              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED'
+              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED,PULL_REQUEST_MERGED'
             - Type: BASE_REF
               Pattern: !Sub '^${GithubBranchName}$'
             - Type: ACTOR_ACCOUNT_ID
               Pattern: '4751028' # fierlion
           - - Type: EVENT
-              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED'
+              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED,PULL_REQUEST_MERGED'
             - Type: BASE_REF
               Pattern: !Sub '^${GithubBranchName}$'
             - Type: ACTOR_ACCOUNT_ID
@@ -266,19 +266,19 @@ Resources:
         BuildType: BUILD
         FilterGroups:
           - - Type: EVENT
-              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED'
+              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED,PULL_REQUEST_MERGED'
             - Type: BASE_REF
               Pattern: !Sub '^${GithubBranchName}$'
             - Type: ACTOR_ACCOUNT_ID
               Pattern: '5080306' # prateekchaudhry
           - - Type: EVENT
-              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED'
+              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED,PULL_REQUEST_MERGED'
             - Type: BASE_REF
               Pattern: !Sub '^${GithubBranchName}$'
             - Type: ACTOR_ACCOUNT_ID
               Pattern: '4751028' # fierlion
           - - Type: EVENT
-              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED'
+              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED,PULL_REQUEST_MERGED'
             - Type: BASE_REF
               Pattern: !Sub '^${GithubBranchName}$'
             - Type: ACTOR_ACCOUNT_ID
@@ -317,19 +317,19 @@ Resources:
         BuildType: BUILD
         FilterGroups:
           - - Type: EVENT
-              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED'
+              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED,PULL_REQUEST_MERGED'
             - Type: BASE_REF
               Pattern: !Sub '^${GithubBranchName}$'
             - Type: ACTOR_ACCOUNT_ID
               Pattern: '5080306' # prateekchaudhry
           - - Type: EVENT
-              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED'
+              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED,PULL_REQUEST_MERGED'
             - Type: BASE_REF
               Pattern: !Sub '^${GithubBranchName}$'
             - Type: ACTOR_ACCOUNT_ID
               Pattern: '4751028' # fierlion
           - - Type: EVENT
-              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED'
+              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED,PULL_REQUEST_MERGED'
             - Type: BASE_REF
               Pattern: !Sub '^${GithubBranchName}$'
             - Type: ACTOR_ACCOUNT_ID
@@ -368,19 +368,19 @@ Resources:
         BuildType: BUILD
         FilterGroups:
           - - Type: EVENT
-              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED'
+              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED,PULL_REQUEST_MERGED'
             - Type: BASE_REF
               Pattern: !Sub '^${GithubBranchName}$'
             - Type: ACTOR_ACCOUNT_ID
               Pattern: '5080306' # prateekchaudhry
           - - Type: EVENT
-              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED'
+              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED,PULL_REQUEST_MERGED'
             - Type: BASE_REF
               Pattern: !Sub '^${GithubBranchName}$'
             - Type: ACTOR_ACCOUNT_ID
               Pattern: '4751028' # fierlion
           - - Type: EVENT
-              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED'
+              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED,PULL_REQUEST_MERGED'
             - Type: BASE_REF
               Pattern: !Sub '^${GithubBranchName}$'
             - Type: ACTOR_ACCOUNT_ID
@@ -419,19 +419,19 @@ Resources:
         BuildType: BUILD
         FilterGroups:
           - - Type: EVENT
-              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED'
+              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED,PULL_REQUEST_MERGED'
             - Type: BASE_REF
               Pattern: !Sub '^${GithubBranchName}$'
             - Type: ACTOR_ACCOUNT_ID
               Pattern: '5080306' # prateekchaudhry
           - - Type: EVENT
-              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED'
+              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED,PULL_REQUEST_MERGED'
             - Type: BASE_REF
               Pattern: !Sub '^${GithubBranchName}$'
             - Type: ACTOR_ACCOUNT_ID
               Pattern: '4751028' # fierlion
           - - Type: EVENT
-              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED'
+              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED,PULL_REQUEST_MERGED'
             - Type: BASE_REF
               Pattern: !Sub '^${GithubBranchName}$'
             - Type: ACTOR_ACCOUNT_ID

--- a/build-infrastructure/codebuild-devbuild-stack.yml
+++ b/build-infrastructure/codebuild-devbuild-stack.yml
@@ -235,6 +235,209 @@ Resources:
               Pattern: '3102848' # YashdalfTheGray
         Webhook: true
       Visibility: PRIVATE
+  Amzn2ArmProject:
+    Type: 'AWS::CodeBuild::Project'
+    Properties:
+      Artifacts:
+        Location: !Ref BuildBucketName
+        NamespaceType: NONE
+        OverrideArtifactName: true
+        Packaging: NONE
+        Path: development
+        Type: S3
+      BadgeEnabled: false
+      ConcurrentBuildLimit: 10
+      Description: A CodeBuild project to build artifacts (ARM) on Amazon Linux 2. Builds are triggered by PR creation and updates, and artifacts are saved in S3.
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: 'aws/codebuild/amazonlinux2-aarch64-standard:2.0'
+        ImagePullCredentialsType: CODEBUILD
+        PrivilegedMode: true
+        Type: ARM_CONTAINER
+      Name: !Sub '${BuildProjectName}-amzn2-arm'
+      QueuedTimeoutInMinutes: 60
+      ServiceRole: !Ref ServiceRoleAmzn2Arm
+      Source:
+        BuildSpec: buildspecs/pr-build.yml
+        Location: !Ref GithubFullRepoName
+        Type: GITHUB
+      TimeoutInMinutes: 60
+      Triggers:
+        BuildType: BUILD
+        FilterGroups:
+          - - Type: EVENT
+              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED'
+            - Type: BASE_REF
+              Pattern: !Sub '^${GithubBranchName}$'
+            - Type: ACTOR_ACCOUNT_ID
+              Pattern: '5080306' # prateekchaudhry
+          - - Type: EVENT
+              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED'
+            - Type: BASE_REF
+              Pattern: !Sub '^${GithubBranchName}$'
+            - Type: ACTOR_ACCOUNT_ID
+              Pattern: '4751028' # fierlion
+          - - Type: EVENT
+              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED'
+            - Type: BASE_REF
+              Pattern: !Sub '^${GithubBranchName}$'
+            - Type: ACTOR_ACCOUNT_ID
+              Pattern: '3102848' # YashdalfTheGray
+        Webhook: true
+      Visibility: PRIVATE
+
+  Amzn2AmdProject:
+    Type: 'AWS::CodeBuild::Project'
+    Properties:
+      Artifacts:
+        Location: !Ref BuildBucketName
+        NamespaceType: NONE
+        OverrideArtifactName: true
+        Packaging: NONE
+        Path: development
+        Type: S3
+      BadgeEnabled: false
+      ConcurrentBuildLimit: 10
+      Description: A CodeBuild project to build artifacts (AMD/x86_64) on Amazon Linux 2. Builds are triggered by PR creation and updates, and artifacts are saved in S3.
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: 'aws/codebuild/amazonlinux2-x86_64-standard:4.0'
+        ImagePullCredentialsType: CODEBUILD
+        PrivilegedMode: true
+        Type: LINUX_CONTAINER
+      Name: !Sub '${BuildProjectName}-amzn2-amd'
+      QueuedTimeoutInMinutes: 60
+      ServiceRole: !Ref ServiceRoleAmzn2Amd
+      Source:
+        BuildSpec: buildspecs/pr-build.yml
+        Location: !Ref GithubFullRepoName
+        Type: GITHUB
+      TimeoutInMinutes: 60
+      Triggers:
+        BuildType: BUILD
+        FilterGroups:
+          - - Type: EVENT
+              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED'
+            - Type: BASE_REF
+              Pattern: !Sub '^${GithubBranchName}$'
+            - Type: ACTOR_ACCOUNT_ID
+              Pattern: '5080306' # prateekchaudhry
+          - - Type: EVENT
+              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED'
+            - Type: BASE_REF
+              Pattern: !Sub '^${GithubBranchName}$'
+            - Type: ACTOR_ACCOUNT_ID
+              Pattern: '4751028' # fierlion
+          - - Type: EVENT
+              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED'
+            - Type: BASE_REF
+              Pattern: !Sub '^${GithubBranchName}$'
+            - Type: ACTOR_ACCOUNT_ID
+              Pattern: '3102848' # YashdalfTheGray
+        Webhook: true
+      Visibility: PRIVATE
+
+  Amzn2023ArmProject:
+    Type: 'AWS::CodeBuild::Project'
+    Properties:
+      Artifacts:
+        Location: !Ref BuildBucketName
+        NamespaceType: NONE
+        OverrideArtifactName: true
+        Packaging: NONE
+        Path: development
+        Type: S3
+      BadgeEnabled: false
+      ConcurrentBuildLimit: 10
+      Description: A CodeBuild project to build artifacts (ARM) on Amazon-Linux 2023. Builds are triggered by PR creation and updates, and artifacts are saved in S3.
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: 'aws/codebuild/amazonlinux2-aarch64-standard:3.0'
+        ImagePullCredentialsType: CODEBUILD
+        PrivilegedMode: true
+        Type: ARM_CONTAINER
+      Name: !Sub '${BuildProjectName}-amzn2023-arm'
+      QueuedTimeoutInMinutes: 60
+      ServiceRole: !Ref ServiceRoleAmzn2023Arm
+      Source:
+        BuildSpec: buildspecs/pr-build.yml
+        Location: !Ref GithubFullRepoName
+        Type: GITHUB
+      TimeoutInMinutes: 60
+      Triggers:
+        BuildType: BUILD
+        FilterGroups:
+          - - Type: EVENT
+              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED'
+            - Type: BASE_REF
+              Pattern: !Sub '^${GithubBranchName}$'
+            - Type: ACTOR_ACCOUNT_ID
+              Pattern: '5080306' # prateekchaudhry
+          - - Type: EVENT
+              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED'
+            - Type: BASE_REF
+              Pattern: !Sub '^${GithubBranchName}$'
+            - Type: ACTOR_ACCOUNT_ID
+              Pattern: '4751028' # fierlion
+          - - Type: EVENT
+              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED'
+            - Type: BASE_REF
+              Pattern: !Sub '^${GithubBranchName}$'
+            - Type: ACTOR_ACCOUNT_ID
+              Pattern: '3102848' # YashdalfTheGray
+        Webhook: true
+      Visibility: PRIVATE
+
+  Amzn2023AmdProject:
+    Type: 'AWS::CodeBuild::Project'
+    Properties:
+      Artifacts:
+        Location: !Ref BuildBucketName
+        NamespaceType: NONE
+        OverrideArtifactName: true
+        Packaging: NONE
+        Path: development
+        Type: S3
+      BadgeEnabled: false
+      ConcurrentBuildLimit: 10
+      Description: A CodeBuild project to build artifacts (AMD/x86_64) on Amazon-Linux 2023. Builds are triggered by PR creation and updates, and artifacts are saved in S3.
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: 'aws/codebuild/amazonlinux2-x86_64-standard:5.0'
+        ImagePullCredentialsType: CODEBUILD
+        PrivilegedMode: true
+        Type: LINUX_CONTAINER
+      Name: !Sub '${BuildProjectName}-amzn2023-amd'
+      QueuedTimeoutInMinutes: 60
+      ServiceRole: !Ref ServiceRoleAmzn2023Amd
+      Source:
+        BuildSpec: buildspecs/pr-build.yml
+        Location: !Ref GithubFullRepoName
+        Type: GITHUB
+      TimeoutInMinutes: 60
+      Triggers:
+        BuildType: BUILD
+        FilterGroups:
+          - - Type: EVENT
+              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED'
+            - Type: BASE_REF
+              Pattern: !Sub '^${GithubBranchName}$'
+            - Type: ACTOR_ACCOUNT_ID
+              Pattern: '5080306' # prateekchaudhry
+          - - Type: EVENT
+              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED'
+            - Type: BASE_REF
+              Pattern: !Sub '^${GithubBranchName}$'
+            - Type: ACTOR_ACCOUNT_ID
+              Pattern: '4751028' # fierlion
+          - - Type: EVENT
+              Pattern: 'PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED'
+            - Type: BASE_REF
+              Pattern: !Sub '^${GithubBranchName}$'
+            - Type: ACTOR_ACCOUNT_ID
+              Pattern: '3102848' # YashdalfTheGray
+        Webhook: true
+      Visibility: PRIVATE     
   ServiceRoleAmd:
     Type: 'AWS::IAM::Role'
     Properties:
@@ -407,3 +610,178 @@ Resources:
                   - 's3:GetBucketLocation'
           PolicyName: !Sub '${AWS::StackName}-ServicePolicyUbuntuArm'
       RoleName: !Sub '${AWS::StackName}-ServiceRoleUbuntuArm'
+  ServiceRoleAmzn2Arm:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: codebuild.amazonaws.com
+            Action: 'sts:AssumeRole'
+      Description: Service role, allow access to CW and S3
+      Path: /
+      Policies:
+        - PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Resource:
+                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${BuildProjectName}-amzn2-arm"
+                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${BuildProjectName}-amzn2-arm:*"
+                Action:
+                  - 'logs:CreateLogGroup'
+                  - 'logs:CreateLogStream'
+                  - 'logs:PutLogEvents'
+              - Effect: Allow
+                Resource:
+                  - 'arn:aws:s3:::codepipeline-us-west-2-*'
+                Action:
+                  - 's3:PutObject'
+                  - 's3:GetObject'
+                  - 's3:GetObjectVersion'
+                  - 's3:GetBucketAcl'
+                  - 's3:GetBucketLocation'
+              - Effect: Allow
+                Resource:
+                  - !Sub '${BuildBucketArn}/*'
+                Action:
+                  - 's3:GetObject'
+                  - 's3:PutObject'
+                  - 's3:GetBucketAcl'
+                  - 's3:GetBucketLocation'
+          PolicyName: !Sub '${AWS::StackName}-ServicePolicyAmzn2Arm'
+      RoleName: !Sub '${AWS::StackName}-ServiceRoleAmzn2Arm'
+
+  ServiceRoleAmzn2Amd:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: codebuild.amazonaws.com
+            Action: 'sts:AssumeRole'
+      Description: Service role, allow access to CW and S3
+      Path: /
+      Policies:
+        - PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Resource:
+                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${BuildProjectName}-amzn2-amd"
+                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${BuildProjectName}-amzn2-amd:*"
+                Action:
+                  - 'logs:CreateLogGroup'
+                  - 'logs:CreateLogStream'
+                  - 'logs:PutLogEvents'
+              - Effect: Allow
+                Resource:
+                  - 'arn:aws:s3:::codepipeline-us-west-2-*'
+                Action:
+                  - 's3:PutObject'
+                  - 's3:GetObject'
+                  - 's3:GetObjectVersion'
+                  - 's3:GetBucketAcl'
+                  - 's3:GetBucketLocation'
+              - Effect: Allow
+                Resource:
+                  - !Sub '${BuildBucketArn}/*'
+                Action:
+                  - 's3:GetObject'
+                  - 's3:PutObject'
+                  - 's3:GetBucketAcl'
+                  - 's3:GetBucketLocation'
+          PolicyName: !Sub '${AWS::StackName}-ServicePolicyAmzn2Amd'
+      RoleName: !Sub '${AWS::StackName}-ServiceRoleAmzn2Amd'
+
+  ServiceRoleAmzn2023Arm:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: codebuild.amazonaws.com
+            Action: 'sts:AssumeRole'
+      Description: Service role, allow access to CW and S3
+      Path: /
+      Policies:
+        - PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Resource:
+                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${BuildProjectName}-amzn2023-arm"
+                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${BuildProjectName}-amzn2023-arm:*"
+                Action:
+                  - 'logs:CreateLogGroup'
+                  - 'logs:CreateLogStream'
+                  - 'logs:PutLogEvents'
+              - Effect: Allow
+                Resource:
+                  - 'arn:aws:s3:::codepipeline-us-west-2-*'
+                Action:
+                  - 's3:PutObject'
+                  - 's3:GetObject'
+                  - 's3:GetObjectVersion'
+                  - 's3:GetBucketAcl'
+                  - 's3:GetBucketLocation'
+              - Effect: Allow
+                Resource:
+                  - !Sub '${BuildBucketArn}/*'
+                Action:
+                  - 's3:GetObject'
+                  - 's3:PutObject'
+                  - 's3:GetBucketAcl'
+                  - 's3:GetBucketLocation'
+          PolicyName: !Sub '${AWS::StackName}-ServicePolicyAmzn2023Arm'
+      RoleName: !Sub '${AWS::StackName}-ServiceRoleAmzn2023Arm'
+
+  ServiceRoleAmzn2023Amd:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: codebuild.amazonaws.com
+            Action: 'sts:AssumeRole'
+      Description: Service role, allow access to CW and S3
+      Path: /
+      Policies:
+        - PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Resource:
+                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${BuildProjectName}-amzn2023-amd"
+                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${BuildProjectName}-amzn2023-amd:*"
+                Action:
+                  - 'logs:CreateLogGroup'
+                  - 'logs:CreateLogStream'
+                  - 'logs:PutLogEvents'
+              - Effect: Allow
+                Resource:
+                  - 'arn:aws:s3:::codepipeline-us-west-2-*'
+                Action:
+                  - 's3:PutObject'
+                  - 's3:GetObject'
+                  - 's3:GetObjectVersion'
+                  - 's3:GetBucketAcl'
+                  - 's3:GetBucketLocation'
+              - Effect: Allow
+                Resource:
+                  - !Sub '${BuildBucketArn}/*'
+                Action:
+                  - 's3:GetObject'
+                  - 's3:PutObject'
+                  - 's3:GetBucketAcl'
+                  - 's3:GetBucketLocation'
+          PolicyName: !Sub '${AWS::StackName}-ServicePolicyAmzn2023Amd'
+      RoleName: !Sub '${AWS::StackName}-ServiceRoleAmzn2023Amd'

--- a/build-infrastructure/codebuild-devbuild-stack.yml
+++ b/build-infrastructure/codebuild-devbuild-stack.yml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: A Cloudformation template to build Agent artifacts on PR creation and modification. It spawns CodeBuild projects for different architectures which trigger agent artifact builds for PR creation and modification, and store the artifacts in an S3 bucket.
+Description: A Cloudformation template to build Agent artifacts on PR creation, modification, and merges. It spawns CodeBuild projects for different architectures which trigger agent artifact builds for PR creation, modification, and merges, and store the artifacts in an S3 bucket.
 
 Parameters:
   GithubFullRepoName:
@@ -31,7 +31,7 @@ Resources:
         Type: S3
       BadgeEnabled: false
       ConcurrentBuildLimit: 10
-      Description: A CodeBuild project to build artifacts (AMD/x86_64). Builds are triggered by PR creation and updates, and artifacts are saved in S3
+      Description: A CodeBuild project to build artifacts (AMD/x86_64). Builds are triggered by PR creation, updates, and merges, and artifacts are saved in S3
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
         Image: 'public.ecr.aws/lts/ubuntu:20.04'
@@ -85,7 +85,7 @@ Resources:
         Type: S3
       BadgeEnabled: false
       ConcurrentBuildLimit: 10
-      Description: A CodeBuild project to build artifacts (ARM). Builds are triggered by PR creation and updates, and artifacts are saved in S3
+      Description: A CodeBuild project to build artifacts (ARM). Builds are triggered by PR creation, updates, and merges, and artifacts are saved in S3
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
         Image: 'public.ecr.aws/lts/ubuntu:20.04'
@@ -139,7 +139,7 @@ Resources:
         Type: S3
       BadgeEnabled: false
       ConcurrentBuildLimit: 10
-      Description: A CodeBuild project to build artifacts (ARM). Builds are triggered by PR creation and updates, and artifacts are saved in S3
+      Description: A CodeBuild project to build artifacts (ARM). Builds are triggered by PR creation, updates, and merges, and artifacts are saved in S3
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
         Image: 'aws/codebuild/amazonlinux2-aarch64-standard:3.0'
@@ -193,7 +193,7 @@ Resources:
         Type: S3
       BadgeEnabled: false
       ConcurrentBuildLimit: 10
-      Description: A CodeBuild project to build artifacts (AMD/x86_64). Builds are triggered by PR creation and updates, and artifacts are saved in S3
+      Description: A CodeBuild project to build artifacts (AMD/x86_64). Builds are triggered by PR creation, updates, and merges, and artifacts are saved in S3
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
         Image: 'aws/codebuild/amazonlinux2-x86_64-standard:5.0'
@@ -249,7 +249,7 @@ Resources:
         Type: S3
       BadgeEnabled: false
       ConcurrentBuildLimit: 10
-      Description: A CodeBuild project to build artifacts (ARM) on Amazon Linux 2. Builds are triggered by PR creation and updates, and artifacts are saved in S3.
+      Description: A CodeBuild project to build artifacts (ARM) on Amazon Linux 2. Builds are triggered by PR creation, updates, and merges, and artifacts are saved in S3.
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
         Image: 'aws/codebuild/amazonlinux2-aarch64-standard:2.0'
@@ -301,7 +301,7 @@ Resources:
         Type: S3
       BadgeEnabled: false
       ConcurrentBuildLimit: 10
-      Description: A CodeBuild project to build artifacts (AMD/x86_64) on Amazon Linux 2. Builds are triggered by PR creation and updates, and artifacts are saved in S3.
+      Description: A CodeBuild project to build artifacts (AMD/x86_64) on Amazon Linux 2. Builds are triggered by PR creation, updates, and merges, and artifacts are saved in S3.
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
         Image: 'aws/codebuild/amazonlinux2-x86_64-standard:4.0'
@@ -353,7 +353,7 @@ Resources:
         Type: S3
       BadgeEnabled: false
       ConcurrentBuildLimit: 10
-      Description: A CodeBuild project to build artifacts (ARM) on Amazon-Linux 2023. Builds are triggered by PR creation and updates, and artifacts are saved in S3.
+      Description: A CodeBuild project to build artifacts (ARM) on Amazon-Linux 2023. Builds are triggered by PR creation, updates, and merges, and artifacts are saved in S3.
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
         Image: 'aws/codebuild/amazonlinux2-aarch64-standard:3.0'
@@ -405,7 +405,7 @@ Resources:
         Type: S3
       BadgeEnabled: false
       ConcurrentBuildLimit: 10
-      Description: A CodeBuild project to build artifacts (AMD/x86_64) on Amazon-Linux 2023. Builds are triggered by PR creation and updates, and artifacts are saved in S3.
+      Description: A CodeBuild project to build artifacts (AMD/x86_64) on Amazon-Linux 2023. Builds are triggered by PR creation, updates, and merges, and artifacts are saved in S3.
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
         Image: 'aws/codebuild/amazonlinux2-x86_64-standard:5.0'


### PR DESCRIPTION
### Summary
To create Amazon Linux RPMs with CodeBuild, the CloudFormation Stack template must reflect the necessary configurations.

Four new CodeBuild Jobs have been added to the template along with their respective service roles:
* agent-dev-amzn2-arm (amazonlinux2-aarch64-standard:2.0) - Amazon Linux 2 ARM
* agent-dev-amzn2-amd (amazonlinux2-x86_64-standard:4.0) - Amazon Linux 2 AMD
* agent-dev-amzn2023-arm (amazonlinux2-aarch64-standard:3.0) - Amazon-Linux 2023 ARM
* agent-dev-amzn2023-amd (amazonlinux2-x86_64-standard:5.0) - Amazon-Linux 2023 AMD

Additionally, "PULL_REQUEST_MERGED" was added to the webhook filter patterns. This will trigger builds for every merge into the dev branch. 

### Testing
AWS CloudFormation Validator `aws cloudformation validate-template` was used to validate the syntax and structure of the template after changes. The template was tested using AWS CLI in a separate account to verify the creation of the 4 new Codebuild jobs. The Validation and CloudFormatino process testing steps produced the expected results. 

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
